### PR TITLE
feat(notes): [INFRA-306] DataLoader for highlight notes

### DIFF
--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -1,8 +1,31 @@
 import knex, { Knex } from 'knex';
 import config from '../config';
+import { DynamoDBClient, DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
 
 let readDb: Knex;
 let writeDb: Knex;
+let dynamoDb: DynamoDBClient;
+
+/**
+ * Create shared DynamoDB Client. By deafult, reuses connections.
+ * This is because the overhead of creating a new TCP connection
+ * for each DynamoDB request might be greater latency than the
+ * operation itself.
+ * See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-reusing-connections.html
+ * @returns DynamoDBClient
+ */
+export function dynamoClient(): DynamoDBClient {
+  if (dynamoDb) return dynamoDb;
+  const dynamoClientConfig: DynamoDBClientConfig = {
+    region: config.aws.region,
+  };
+  // Set endpoint for local client, otherwise provider default
+  if (config.aws.endpoint != null) {
+    dynamoClientConfig['endpoint'] = config.aws.endpoint;
+  }
+  dynamoDb = new DynamoDBClient(dynamoClientConfig);
+  return dynamoDb;
+}
 
 /**
  * Create a db client for reads from readitla_ril-tmp

--- a/src/dataservices/dataloaders.spec.ts
+++ b/src/dataservices/dataloaders.spec.ts
@@ -1,0 +1,46 @@
+import sinon from 'sinon';
+import { NotesDataService } from '../dataservices/notes';
+import { dynamoClient } from '../database/client';
+import { createNotesLoader } from './dataloaders';
+
+describe('dataloaders', () => {
+  describe('for HighlightNotes', () => {
+    let notesStub;
+    let notesLoader;
+    // This is required for NotesDataServiceconstructor,
+    // but fetch is never invoked because we mock the data retrieval function
+    const dynamo = dynamoClient();
+    beforeEach(() => {
+      notesStub = sinon.stub(NotesDataService.prototype, 'getMany').resolves([
+        { highlightId: 'abc', text: 'bread' },
+        { highlightId: 'def', text: 'garlic' },
+        { highlightId: 'hij', text: 'yummy' },
+      ]);
+      notesLoader = createNotesLoader(dynamo);
+    });
+    afterEach(() => {
+      notesStub.restore();
+    });
+    it('reorders data by highlightId', async () => {
+      const result = await notesLoader.loadMany(['hij', 'def', 'abc', 'hij']);
+      const expected = [
+        { highlightId: 'hij', text: 'yummy' },
+        { highlightId: 'def', text: 'garlic' },
+        { highlightId: 'abc', text: 'bread' },
+        { highlightId: 'hij', text: 'yummy' }, // retrieved from cache
+      ];
+      expect(result).toStrictEqual(expected);
+      // Should get subsequent duplicate keys from cache
+      expect(notesStub.calledOnceWith(['hij', 'def', 'abc'])).toBe(true);
+    });
+    it('returns undefined object if data is missing for key', async () => {
+      const result = await notesLoader.loadMany(['zzz', 'def', 'abc']);
+      const expected = [
+        undefined,
+        { highlightId: 'def', text: 'garlic' },
+        { highlightId: 'abc', text: 'bread' },
+      ];
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/src/dataservices/dataloaders.ts
+++ b/src/dataservices/dataloaders.ts
@@ -1,0 +1,29 @@
+import DataLoader from 'dataloader';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { NotesDataService } from './notes';
+import { HighlightNote } from '../types';
+
+export function createNotesLoader(
+  client: DynamoDBClient
+): DataLoader<string, HighlightNote | undefined> {
+  return new DataLoader<string, HighlightNote | undefined>(
+    async (keys: string[]) => {
+      const notes = await new NotesDataService(client).getMany(keys);
+      // there might be missing/different ordered keys
+      // we need these to be explicitly included, even if undefined,
+      // so that the response has the same expected length and order
+      return orderAndMapNotes(keys, notes);
+    }
+  );
+}
+
+function orderAndMapNotes(
+  keys: string[],
+  notesResponse: HighlightNote[]
+): Array<HighlightNote | undefined> {
+  const noteKeyMap = notesResponse.reduce((keyMap, currentNote) => {
+    keyMap[currentNote.highlightId] = currentNote;
+    return keyMap;
+  }, {});
+  return keys.map((key) => noteKeyMap[key]);
+}

--- a/src/dataservices/dataloaders.ts
+++ b/src/dataservices/dataloaders.ts
@@ -3,6 +3,13 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { NotesDataService } from './notes';
 import { HighlightNote } from '../types';
 
+/**
+ * Function for initializing dataloader. This function should be
+ * called when the context is constructed to create a new dataloader
+ * instance for each request.
+ * @param client DynamoDB Client to use inside NotesDataService
+ * @returns DataLoader which loads HighlightNote objects by highlightId string key
+ */
 export function createNotesLoader(
   client: DynamoDBClient
 ): DataLoader<string, HighlightNote | undefined> {
@@ -17,6 +24,13 @@ export function createNotesLoader(
   );
 }
 
+/**
+ * Function for reordering keys in case the order is not preserved when loading,
+ * or some keys are missing.
+ * @param keys keys passed to the dataloader
+ * @param notesResponse the response from the server/cache containing the data
+ * @returns an array of notes (or undefined) that match the shape of the keys input
+ */
 function orderAndMapNotes(
   keys: string[],
   notesResponse: HighlightNote[]

--- a/src/dataservices/notes.integration.ts
+++ b/src/dataservices/notes.integration.ts
@@ -1,0 +1,58 @@
+import sinon from 'sinon';
+import { NotesDataService } from './notes';
+import { BatchGetCommandOutput } from '@aws-sdk/lib-dynamodb';
+import config from '../config';
+
+describe('Notes data service', () => {
+  let dynamoSendStub: sinon.stub;
+  const service = new NotesDataService();
+
+  const dynamoFirstResult: BatchGetCommandOutput = {
+    Responses: {
+      [config.dynamoDb.notesTable.name]: [
+        { id: 1, note: 'what a zesty pâté' },
+        { id: 2, note: 'I feel like a hummingbird' },
+      ],
+    },
+    UnprocessedKeys: {
+      table: {
+        Keys: [{ id: 3 }],
+      },
+    },
+    $metadata: {},
+  };
+  const dynamoSecondResult: BatchGetCommandOutput = {
+    Responses: {
+      [config.dynamoDb.notesTable.name]: [
+        { id: 3, note: 'scalier than a dehydrated komodo' },
+      ],
+    },
+    $metadata: {},
+  };
+  beforeEach(() => {
+    dynamoSendStub = sinon
+      .stub(service.dynamo, 'send')
+      .onFirstCall()
+      .resolves(dynamoFirstResult)
+      .onSecondCall()
+      .resolves(dynamoSecondResult);
+  });
+  afterEach(() => {
+    dynamoSendStub.restore();
+  });
+  it('retries unprocessed keys and concatenates results', async () => {
+    const result = await service.getMany(['1', '2', '3']);
+    const expectedText = [
+      'what a zesty pâté',
+      'I feel like a hummingbird',
+      'scalier than a dehydrated komodo',
+    ];
+    expect(result?.length).toEqual(3);
+    // Ignore the additional undefined fields from the toGraphQL function
+    // just examine text
+    const textResult = result?.map((_) => _.text);
+    expect(textResult).toStrictEqual(expectedText);
+    // Should have called `send` twice to finish the batch
+    expect(dynamoSendStub.callCount).toEqual(2);
+  });
+});

--- a/src/dataservices/notes.integration.ts
+++ b/src/dataservices/notes.integration.ts
@@ -2,10 +2,11 @@ import sinon from 'sinon';
 import { NotesDataService } from './notes';
 import { BatchGetCommandOutput } from '@aws-sdk/lib-dynamodb';
 import config from '../config';
+import { dynamoClient } from '../database/client';
 
 describe('Notes data service', () => {
   let dynamoSendStub: sinon.stub;
-  const service = new NotesDataService();
+  const service = new NotesDataService(dynamoClient());
 
   const dynamoFirstResult: BatchGetCommandOutput = {
     Responses: {

--- a/src/dataservices/notes.ts
+++ b/src/dataservices/notes.ts
@@ -56,7 +56,11 @@ export class NotesDataService {
     }
     return null;
   }
-
+  /**
+   * Fetch a batch of notes attached to a highlight
+   * @param ids array of highlight's ids to fetch (annotation_id in the Pocket db)
+   * @returns array of HighlightNote objects
+   */
   public async getMany(ids: string[]): Promise<Array<HighlightNote>> {
     const keyList = ids.map((id) => ({ [this.table.key]: id }));
     let unprocessedKeys: BatchGetCommandInput['RequestItems'] = {

--- a/src/dataservices/utils.ts
+++ b/src/dataservices/utils.ts
@@ -1,0 +1,15 @@
+import { setTimeout } from 'timers/promises';
+
+/**
+ * Exponential backoff with full jitter.
+ * @param tries number of re(tries). Used for exonential backoff
+ * calculation
+ * @param cap Backoff time cap, in ms. Will not back off any
+ * longer than this value
+ */
+export async function backoff(tries: number, cap: number) {
+  const maxWait = Math.min(cap, 2 ** tries * 100);
+  // Pick random number from set [0, maxWait]
+  const jitterWait = Math.floor(Math.random() * (maxWait + 1) + 0);
+  await setTimeout(jitterWait);
+}

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -7,7 +7,6 @@ import {
   HighlightNote,
 } from './types';
 import { HighlightsDataService } from './dataservices/highlights';
-import { NotesDataService } from './dataservices/notes';
 
 export const resolvers = {
   SavedItem: {
@@ -27,8 +26,8 @@ export const resolvers = {
       parent: Highlight,
       _,
       context: IContext
-    ): Promise<HighlightNote | null> => {
-      return new NotesDataService().get(parent.id);
+    ): Promise<HighlightNote | undefined> => {
+      return context.dataLoaders.noteByHighlightId.load(parent.id);
     },
   },
   Mutation: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import {
   ApolloServerPluginInlineTrace,
 } from 'apollo-server-core';
 import { ContextManager } from './context';
-import { readClient, writeClient } from './database/client';
+import { dynamoClient, readClient, writeClient } from './database/client';
 
 export function getServer(): ApolloServer {
   return new ApolloServer({
@@ -28,6 +28,7 @@ export function getServer(): ApolloServer {
       new ContextManager({
         request: req,
         db: { readClient: readClient(), writeClient: writeClient() },
+        dynamoClient: dynamoClient(),
       }),
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type Highlight = {
 };
 
 export type HighlightNote = {
-  highlightId?: string;
+  highlightId: string;
   text: string;
   _createdAt: number;
   _updatedAt: number;
@@ -30,7 +30,7 @@ export type HighlightNote = {
 
 // In DynamoDB can't use underscore in projection expression
 export type HighlightNoteEntity = {
-  highlightId?: string;
+  highlightId: string;
   note: string; // text is reserved keyword
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
## Goal
Create a per-request DataLoader for loading highlight notes from DynamoDB store.

- Create a DataLoader on each new Context object (per-request) and invoke in `Highlight.note` resolver
- Create a batch loading function to retrieve responses from DynamoDB
- Create a shared, long-lived DynamoDB client to pass around to requests due to TCP connection overhead -- see https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-reusing-connections.html

## I'd love feedback/perspectives on:
- per-request memory map cache vs. shared redis cache pros/cons?

## Implementation Decisions
- Not using the shared redis cache + apollo-utils tooling, because really just want to cache per request (don't need a longer lived cache, scoped only to this user and request). Default dataloader behavior seems to suffice

## References

JIRA ticket:
* [INFRA-306]
