### PR TITLE
feat(highlights): log highlight mutations to users_meta table

### DIFF
--- a/.docker/mysql/schema/schema.sql
+++ b/.docker/mysql/schema/schema.sql
@@ -25,3 +25,17 @@ CREATE TABLE IF NOT EXISTS `list` (
   `item_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`user_id`,`item_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+
+-- this table stores timestamps for changes to various entities
+-- stores changes to highlights for this service
+CREATE TABLE `users_meta` (
+  `user_id` int(10) unsigned NOT NULL,
+  `property` tinyint(3) unsigned NOT NULL,
+  `value` text NOT NULL,
+  `time_updated` datetime NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`user_id`,`property`,`time_updated`),
+  KEY `property` (`property`),
+  KEY `time_updated` (`time_updated`),
+  KEY `updated_at` (`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "graphql-anywhere": "^4.2.7",
         "graphql-tag": "^2.12.6",
         "knex": "^1.0.2",
+        "luxon": "^2.3.1",
         "mysql": "^2.18.1"
       },
       "devDependencies": {
@@ -7054,6 +7055,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.1.tgz",
+      "integrity": "sha512-I8vnjOmhXsMSlNMZlMkSOvgrxKJl0uOsEzdGgGNZuZPaS9KlefpE9KV95QFftlJSC+1UyCC9/I69R02cz/zcCA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -14981,6 +14990,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.1.tgz",
+      "integrity": "sha512-I8vnjOmhXsMSlNMZlMkSOvgrxKJl0uOsEzdGgGNZuZPaS9KlefpE9KV95QFftlJSC+1UyCC9/I69R02cz/zcCA=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "graphql-anywhere": "^4.2.7",
     "graphql-tag": "^2.12.6",
     "knex": "^1.0.2",
+    "luxon": "^2.3.1",
     "mysql": "^2.18.1"
   },
   "devDependencies": {

--- a/src/dataservices/usersMeta.ts
+++ b/src/dataservices/usersMeta.ts
@@ -1,0 +1,67 @@
+import { Knex } from 'knex';
+import { mysqlTimeString } from './utils';
+import config from '../config';
+import { IContext } from '../context';
+
+export class UsersMeta {
+  public static propertiesMap = {
+    account: 41,
+  };
+  private static tableName = 'users_meta';
+
+  private db: Knex.QueryBuilder;
+  private knex: Knex;
+  private readonly userId: string;
+
+  constructor(context: IContext) {
+    this.userId = context.userId;
+    this.knex = context.db.writeClient;
+    this.db = context.db.writeClient(UsersMeta.tableName);
+  }
+
+  /**
+   * Log the last time an annotation mutation occurred.
+   * There should only be one entry for the unique combination of user_id:property
+   * Since this should only be updated as a side-effect of another mutation, require
+   * a transaction object to conduct the entire operation atomically.
+   * @param timestamp timestamp server processed mutation
+   * @param trx
+   */
+  public async logAnnotationMutation(
+    timestamp: Date,
+    trx: Knex.Transaction
+  ): Promise<void> {
+    const propertyCode = UsersMeta.propertiesMap.account;
+    // The table should be unique on property:user_id for annotations log
+    await this.deleteByProperty(propertyCode).transacting(trx);
+    await this.insertTimestampByProperty(propertyCode, timestamp).transacting(
+      trx
+    );
+  }
+
+  /**
+   * Delete a row by user_id and property. Ensures uniqueness on these two
+   * fields (e.g. if you only want to track the last time a tag was changed)
+   * @param property numerical code that identifies the tracked property
+   */
+  private deleteByProperty(property: number): Knex.QueryBuilder {
+    return this.db.where({ user_id: this.userId, property: property }).del();
+  }
+
+  /**
+   * Inserts a timestamp into the users_meta table.
+   * @param property numerical code for identifying the tracked property
+   * @param timestamp timestamp at which the tracked change occurred
+   */
+  private insertTimestampByProperty(
+    property: number,
+    timestamp: Date
+  ): Knex.QueryBuilder {
+    return this.db.insert({
+      user_id: this.userId,
+      property: property,
+      value: mysqlTimeString(timestamp, config.database.tz),
+      time_updated: this.knex.fn.now(), // Web repo uses NOW() instead of server timestamp
+    });
+  }
+}

--- a/src/dataservices/utils.ts
+++ b/src/dataservices/utils.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from 'timers/promises';
+import { DateTime } from 'luxon';
 
 /**
  * Exponential backoff with full jitter.
@@ -12,4 +13,17 @@ export async function backoff(tries: number, cap: number) {
   // Pick random number from set [0, maxWait]
   const jitterWait = Math.floor(Math.random() * (maxWait + 1) + 0);
   await setTimeout(jitterWait);
+}
+
+/**
+ * Convert date object to timestamp as a string (yyyy-MM-dd HH:mm:ss)
+ * localized to a time zone.
+ * Used for database timestamp strings in text columns
+ * (e.g. users_meta.value)
+ * @param timestamp the date object to localize and return as string
+ * @param tz the timezone string for the timezone
+ */
+export function mysqlTimeString(timestamp: Date, tz: string): string {
+  const dt = DateTime.fromMillis(timestamp.getTime()).setZone(tz);
+  return dt.toFormat('yyyy-MM-dd HH:mm:ss');
 }


### PR DESCRIPTION
## Goal

Log highlight mutations (create/update/delete) to `users_meta` table. This allows clients to sync changes to annotations for a given `savedItem` 

## I'd love feedback/perspectives on:
- I mostly copied what we do in `list-api`. Please let me know if something looks out of place.

## References

JIRA ticket: INFRA-298
