### PR TITLE
fix: point to localstack only if the env is not both prod and dev

### DIFF
--- a/.aws/src/SqsLambda.ts
+++ b/.aws/src/SqsLambda.ts
@@ -24,6 +24,7 @@ export class SqsLambda extends Resource {
       name: `${config.prefix}-Sqs-Event-Consumer`,
       batchSize: 10,
       batchWindow: 60,
+      functionResponseTypes: ['ReportBatchItemFailures'],
       sqsQueue: {
         maxReceiveCount: 3,
         visibilityTimeoutSeconds: 300,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "annotations-api",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,28 +37,28 @@
     "aws-xray-sdk-core": "3.3.6",
     "aws-xray-sdk-express": "3.3.6",
     "dataloader": "2.1.0",
+    "express-validator": "6.14.1",
     "knex": "1.0.7",
     "luxon": "2.4.0",
     "mysql": "2.18.1",
-    "express-validator": "6.14.1",
     "nanoid": "3.3.4"
   },
   "devDependencies": {
     "@pocket-tools/eslint-config": "1.1.0",
     "@pocket-tools/tsconfig": "1.0.2",
     "@types/chai": "4.3.1",
+    "@types/chance": "1.1.3",
     "@types/jest": "27.5.1",
     "@types/node": "16.11.35",
     "@types/uuid": "8.3.4",
     "chai": "4.3.6",
+    "chance": "1.1.8",
     "jest": "28.1.0",
     "nock": "13.2.6",
     "nodemon": "2.0.16",
     "sinon": "14.0.0",
+    "supertest": "6.2.3",
     "ts-jest": "28.0.5",
-    "ts-node": "10.8.1",
-    "@types/chance": "1.1.3",
-    "chance": "1.1.8",
-    "supertest": "6.2.3"
+    "ts-node": "10.8.1"
   }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,7 +14,8 @@ export default {
   aws: {
     region: process.env.AWS_REGION || 'us-east-1',
     endpoint:
-      (process.env.NODE_ENV != 'production' && process.env.NODE_ENV != 'development')
+      process.env.NODE_ENV != 'production' &&
+      process.env.NODE_ENV != 'development'
         ? process.env.AWS_ENDPOINT || 'http://localstack:4566'
         : undefined,
     maxBackoff: 3000, // in ms, max amount of backoff time allowed for multiple requests

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,7 +14,7 @@ export default {
   aws: {
     region: process.env.AWS_REGION || 'us-east-1',
     endpoint:
-      process.env.NODE_ENV != 'production'
+      (process.env.NODE_ENV != 'production' && process.env.NODE_ENV != 'development')
         ? process.env.AWS_ENDPOINT || 'http://localstack:4566'
         : undefined,
     maxBackoff: 3000, // in ms, max amount of backoff time allowed for multiple requests


### PR DESCRIPTION
## Goal
- to assign only localstack url if the env is not dev and prod
- enable batchFailure in aws configuration