### PR TITLE
fix(account-deletion): convert userId to string

### DIFF
--- a/src/server/routes/queueDelete.ts
+++ b/src/server/routes/queueDelete.ts
@@ -53,7 +53,7 @@ router.post(
     const requestId = req.body.traceId ?? nanoid();
     const userId = req.body.userId;
     const isPremium = req.body.isPremium;
-    new NotesDataService(dynamoClient(), userId)
+    new NotesDataService(dynamoClient(), userId.toString())
       .clearUserData()
       .then(() => successCallback('Notes', userId, requestId))
       .catch((error) =>


### PR DESCRIPTION
## Goal
Fixes a bug where notes weren't deleted due to wrong data type.

Tested in dev environment and records were successfully deleted.

HighlightsDataService should be initialized with
userId as a string, not number; otherwise will cause
validation errors due to incorrect type in DynamoDB.

## References

JIRA ticket:
* [INFRA-633]


[INFRA-633]: https://getpocket.atlassian.net/browse/INFRA-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ