### PR TITLE
chore: pull APOLLO_KEY from shared context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,8 @@ workflows:
           context: pocket
           name: test_integrations
 
-      - apollo
+      - apollo:
+          context: pocket-prod
 
       - build:
           context: pocket


### PR DESCRIPTION
## Goal

Pull APOLLO_KEY from shared context. Mitigation to make cycling keys easier.