### PR TITLE
chore(elasticache): update elasticache node type based on usage/price

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -11,9 +11,8 @@ const githubConnectionArn = isDev
   : 'arn:aws:codestar-connections:us-east-1:996905175585:connection/5fa5aa2b-a2d2-43e3-ab5a-72ececfc1870';
 const branch = isDev ? 'dev' : 'main';
 
-//Arbitrary size and count for cache. No logic was used in deciding this.
 const cacheNodes = isDev ? 2 : 2;
-const cacheSize = isDev ? 'cache.t2.micro' : 'cache.t3.medium';
+const cacheSize = isDev ? 'cache.t3.micro' : 'cache.t3.micro';
 const appPort = 4008;
 const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
 


### PR DESCRIPTION
## Goal
Reviewed usage and node types now available for Elasticache, recommend using t3.micro for both dev and test

Documentation:
* https://docs.google.com/spreadsheets/d/1IqqRjPTBniE3xTCZytm1Z52_iCwH_jFKHjHDZSPHhLs/edit#gid=0
