### PR TITLE
chore(knex): configure knex connection pooling to drop idle connections

### DIFF
--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -73,6 +73,9 @@ export function createConnection(dbConfig: {
       charset: 'utf8mb4',
     },
     pool: {
+      // knex docs state to set to 0 so that idle connections are released.
+      // default was 2 for legacy knex reasons (according to docs)
+      min: 0,
       /**
        * Explicitly set the session timezone. We don't want to take any chances with this
        */


### PR DESCRIPTION
## Goal

knex's default `min` setting for connection pooling is `2`, which will not release all idle connections (which isn't great for db load). the intent of this PR is to explicitly set `min` to `0` so idle connections can be released (which is [recommended by knex's docs](https://knexjs.org/guide/#pool)).

## Implementation Decisions
- leaving `max` unset - which defaults to `10`

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/INFRA-1358