### PR TITLE
SOCIALPLAT-25-383: adding basic synthetic canary

### DIFF
--- a/.aws/package-lock.json
+++ b/.aws/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@pocket-tools/terraform-modules": "4.14.0"
+        "@pocket-tools/terraform-modules": "4.17.0"
       },
       "devDependencies": {
         "@pocket-tools/tsconfig": "2.0.1",
@@ -459,9 +459,9 @@
       "deprecated": "this package has been deprecated, use `ci-info` instead"
     },
     "node_modules/@pocket-tools/terraform-modules": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-4.14.0.tgz",
-      "integrity": "sha512-A7B97z0LNTycS9XEftuVH4rnW5OTVzTC1/3z9uVE1Jw3rTso6NACngzmhSA1d26Jlk9aI26Vbpr5VqiMW340kw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-4.17.0.tgz",
+      "integrity": "sha512-fZvRWqLo7khQq16Ndt25ojE8vsrMpxXkga5YMdCDnovwMUuvuBKPx/K5oLpNmNTIuWJ6jpaUwXihZbB1TQUa6w==",
       "dependencies": {
         "@cdktf/provider-archive": "4.0.0",
         "@cdktf/provider-aws": "11.0.9",
@@ -470,14 +470,14 @@
         "@cdktf/provider-null": "4.0.1",
         "@cdktf/provider-pagerduty": "4.0.3",
         "@cdktf/provider-time": "4.0.0",
-        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/commons": "^3.0.0",
         "cdktf": "0.14.3",
         "cdktf-cli": "0.14.3",
         "constructs": "10.1.215",
         "parse-domain": "^4.1.0"
       },
       "engines": {
-        "node": ">=16.18"
+        "node": ">=16.20"
       }
     },
     "node_modules/@pocket-tools/tsconfig": {
@@ -571,9 +571,9 @@
       }
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dependencies": {
         "type-detect": "4.0.8"
       }

--- a/.aws/package.json
+++ b/.aws/package.json
@@ -13,7 +13,7 @@
     "test": "echo ok"
   },
   "dependencies": {
-    "@pocket-tools/terraform-modules": "4.14.0"
+    "@pocket-tools/terraform-modules": "4.17.0"
   },
   "devDependencies": {
     "@pocket-tools/tsconfig": "2.0.1",


### PR DESCRIPTION
## Goal
Adding basic synthetic canary. For now, expecting `authentication` error response as we don't have a canary user setup yet to make authenticated requests. This should be done in [another PR/ticket](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-386) + canary code updates.

## References

JIRA ticket:
* [https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-383](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-383)
