### PR TITLE
fix(deps): [INFRA-1372] Update eslint config and deprecated apollo local testing plugin

### DIFF
--- a/.aws/src/SqsLambda.ts
+++ b/.aws/src/SqsLambda.ts
@@ -19,7 +19,7 @@ export class SqsLambda extends Resource {
     vpc: PocketVPC,
     region: DataAwsRegion,
     caller: DataAwsCallerIdentity,
-    pagerDuty?: PocketPagerDuty
+    pagerDuty?: PocketPagerDuty,
   ) {
     super(scope, name);
 

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -57,7 +57,7 @@ class AnnotationsAPI extends TerraformStack {
       'sqs-event-consumer',
       pocketVPC,
       region,
-      caller
+      caller,
     );
 
     const lambda = sqsLambda.lambda;
@@ -71,7 +71,7 @@ class AnnotationsAPI extends TerraformStack {
         sqsQueue: lambda.sqsQueueResource,
         tags: config.tags,
         dependsOn: [lambda.sqsQueueResource as SqsQueue],
-      }
+      },
     );
 
     new ApplicationSQSQueue(this, 'batch-delete-consumer-queue', {
@@ -132,7 +132,7 @@ class AnnotationsAPI extends TerraformStack {
    */
   private static createElasticache(
     scope: Construct,
-    vpc: PocketVPC
+    vpc: PocketVPC,
   ): {
     primaryEndpoint: string;
     readerEndpoint: string;
@@ -216,7 +216,7 @@ class AnnotationsAPI extends TerraformStack {
         workspaces: {
           name: 'incident-management',
         },
-      }
+      },
     );
 
     return new PocketPagerDuty(this, 'pagerduty', {
@@ -473,7 +473,7 @@ class AnnotationsAPI extends TerraformStack {
         retentionInDays: 90,
         skipDestroy: true,
         tags: config.tags,
-      }
+      },
     );
 
     return logGroup.name;

--- a/lambda/events/handlers/accountDelete.ts
+++ b/lambda/events/handlers/accountDelete.ts
@@ -28,7 +28,7 @@ export async function accountDeleteHandler(record: SQSRecord) {
   if (!res.ok) {
     const data = (await res.json()) as any;
     throw new Error(
-      `queueDelete - ${res.status}\n${JSON.stringify(data.errors)}`
+      `queueDelete - ${res.status}\n${JSON.stringify(data.errors)}`,
     );
   }
 }

--- a/lambda/events/index.spec.ts
+++ b/lambda/events/index.spec.ts
@@ -47,7 +47,7 @@ describe('event handlers', () => {
       expect(res.batchItemFailures).toEqual([{ itemIdentifier: 'abc' }]);
       expect(sentryStub.callCount).toEqual(1);
       expect(sentryStub.getCall(0).args[0].message).toEqual(
-        `Unable to retrieve handler for detail-type='NOT_A_TYPE'`
+        `Unable to retrieve handler for detail-type='NOT_A_TYPE'`,
       );
     });
   });

--- a/lambda/events/index.ts
+++ b/lambda/events/index.ts
@@ -16,7 +16,7 @@ export async function processor(event: SQSEvent): Promise<SQSBatchResponse> {
       const message = JSON.parse(JSON.parse(record.body).Message);
       if (handlers[message['detail-type']] == null) {
         throw new Error(
-          `Unable to retrieve handler for detail-type='${message['detail-type']}'`
+          `Unable to retrieve handler for detail-type='${message['detail-type']}'`,
         );
       }
       await handlers[message['detail-type']](record);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "4.9.0",
-        "@apollo/server-plugin-landing-page-graphql-playground": "4.0.1",
         "@apollo/subgraph": "2.5.1",
         "@aws-sdk/client-dynamodb": "3.379.1",
         "@aws-sdk/client-sqs": "3.379.1",
@@ -34,7 +33,7 @@
         "nanoid": "3.3.6"
       },
       "devDependencies": {
-        "@pocket-tools/eslint-config": "2.0.0",
+        "@pocket-tools/eslint-config": "2.1.7",
         "@pocket-tools/tsconfig": "2.0.1",
         "@types/chai": "4.3.5",
         "@types/chance": "1.1.3",
@@ -180,21 +179,6 @@
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server-plugin-landing-page-graphql-playground": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-plugin-landing-page-graphql-playground/-/server-plugin-landing-page-graphql-playground-4.0.1.tgz",
-      "integrity": "sha512-tWhQzD7DtiTO/wfbGvasryz7eJSuEh9XJHgRTMZI7+Wu/omylG5gH6K6ksg1Vccg8/Xuglfi2f1M5Nm/IlBBGw==",
-      "deprecated": "The use of GraphQL Playground in Apollo Server was supported in previous versions, but this is no longer the case as of December 31, 2022. This package exists for v4 migration purposes only. We do not intend to resolve security issues or other bugs with this package if they arise, so please migrate away from this to [Apollo Server's default Explorer](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages) as soon as possible.",
-      "dependencies": {
-        "@apollographql/graphql-playground-html": "1.6.29"
-      },
-      "engines": {
-        "node": ">=14.0"
-      },
-      "peerDependencies": {
-        "@apollo/server": "^4.0.0"
       }
     },
     "node_modules/@apollo/server/node_modules/lru-cache": {
@@ -375,14 +359,6 @@
       "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ==",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@apollographql/graphql-playground-html": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-      "dependencies": {
-        "xss": "^1.0.8"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1652,22 +1628,22 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.1.tgz",
-      "integrity": "sha512-O7x6dMstWLn2ktjcoiNLDkAGG2EjveHL+Vvc+n0fXumkJYAcSqcVYKtwDU+hDZ0uDUsnUagSYaZrOLAYE8un1A==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
+      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
-        "globals": "^13.15.0",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -1676,6 +1652,9 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/js": {
@@ -1733,13 +1712,13 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -2498,17 +2477,19 @@
       }
     },
     "node_modules/@pocket-tools/eslint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/eslint-config/-/eslint-config-2.0.0.tgz",
-      "integrity": "sha512-F9Pxtnla/wN015/T/4uGMV8j+nUATpUZ6yrcNci6QUIoWijUTYhx0iil0lFiTPZ8Q3kyKaV64GDhEi+pAc0XTg==",
-      "dev": true,
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/eslint-config/-/eslint-config-2.1.7.tgz",
+      "integrity": "sha512-NXwPidPMa5rfYyAXdAQH1ooZ8IZIK3vSLpdGmvX5d4XEWdrf69vdpBcdHKn7GzBrAi2qltOpXc9kmrybTQ2HNg==",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "5.28.0",
-        "@typescript-eslint/parser": "5.28.0",
-        "eslint": "8.18.0",
-        "eslint-config-prettier": "8.5.0",
-        "eslint-plugin-prettier": "4.0.0",
-        "prettier": "2.7.1"
+        "@typescript-eslint/eslint-plugin": "6.1.0",
+        "@typescript-eslint/parser": "6.1.0",
+        "eslint": "8.45.0",
+        "eslint-config-prettier": "8.8.0",
+        "eslint-plugin-prettier": "5.0.0",
+        "prettier": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pocket-tools/ts-logger": {
@@ -2526,436 +2507,6 @@
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "winston": "^3.9.0"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@pocket-tools/eslint-config": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/eslint-config/-/eslint-config-2.1.7.tgz",
-      "integrity": "sha512-NXwPidPMa5rfYyAXdAQH1ooZ8IZIK3vSLpdGmvX5d4XEWdrf69vdpBcdHKn7GzBrAi2qltOpXc9kmrybTQ2HNg==",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "6.1.0",
-        "@typescript-eslint/parser": "6.1.0",
-        "eslint": "8.45.0",
-        "eslint-config-prettier": "8.8.0",
-        "eslint-plugin-prettier": "5.0.0",
-        "prettier": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
-      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/type-utils": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
-        "natural-compare": "^1.4.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@typescript-eslint/parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
-      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
-      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
-      "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@typescript-eslint/type-utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
-      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@typescript-eslint/types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
-      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ==",
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
-      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
-      "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@typescript-eslint/utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
-      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
-      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
-      "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/eslint": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
-      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
-        "@humanwhocodes/config-array": "^0.11.10",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
-        "esquery": "^1.4.2",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/eslint-plugin-prettier": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.5"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/eslint-scope": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
-      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/@pocket-tools/ts-logger/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@pocket-tools/tsconfig": {
@@ -4438,31 +3989,33 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.28.0.tgz",
-      "integrity": "sha512-DXVU6Cg29H2M6EybqSg2A+x8DgO9TCUBRp4QEXQHJceLS7ogVDP0g3Lkg/SZCqcvkAP/RruuQqK0gdlkgmhSUA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
+      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.28.0",
-        "@typescript-eslint/type-utils": "5.28.0",
-        "@typescript-eslint/utils": "5.28.0",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/type-utils": "6.1.0",
+        "@typescript-eslint/utils": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.2.0",
-        "regexpp": "^3.2.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4471,25 +4024,25 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.28.0.tgz",
-      "integrity": "sha512-ekqoNRNK1lAcKhZESN/PdpVsWbP9jtiNqzFWkp/yAUdZvJalw2heCYuqRmM5eUJSIYEkgq5sGOjq+ZqsLMjtRA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
+      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.28.0",
-        "@typescript-eslint/types": "5.28.0",
-        "@typescript-eslint/typescript-estree": "5.28.0",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4498,16 +4051,15 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.28.0.tgz",
-      "integrity": "sha512-LeBLTqF/he1Z+boRhSqnso6YrzcKMTQ8bO/YKEe+6+O/JGof9M0g3IJlIsqfrK/6K03MlFIlycbf1uQR1IjE+w==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
+      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
       "dependencies": {
-        "@typescript-eslint/types": "5.28.0",
-        "@typescript-eslint/visitor-keys": "5.28.0"
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4515,24 +4067,24 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.28.0.tgz",
-      "integrity": "sha512-SyKjKh4CXPglueyC6ceAFytjYWMoPHMswPQae236zqe1YbhvCVQyIawesYywGiu98L9DwrxsBN69vGIVxJ4mQQ==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
+      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
       "dependencies": {
-        "@typescript-eslint/utils": "5.28.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/utils": "6.1.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4541,12 +4093,11 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.28.0.tgz",
-      "integrity": "sha512-2OOm8ZTOQxqkPbf+DAo8oc16sDlVR5owgJfKheBkxBKg1vAfw2JsSofH9+16VPlN9PWtv8Wzhklkqw3k/zCVxA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ==",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4554,21 +4105,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.28.0.tgz",
-      "integrity": "sha512-9GX+GfpV+F4hdTtYc6OV9ZkyYilGXPmQpm6AThInpBmKJEyRSIjORJd1G9+bknb7OTFYL+Vd4FBJAO6T78OVqA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
+      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
       "dependencies": {
-        "@typescript-eslint/types": "5.28.0",
-        "@typescript-eslint/visitor-keys": "5.28.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4581,40 +4131,39 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.28.0.tgz",
-      "integrity": "sha512-E60N5L0fjv7iPJV3UGc4EC+A3Lcj4jle9zzR0gW7vXhflO7/J29kwiTGITA2RlrmPokKiZbBy2DgaclCaEUs6g==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
+      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
       "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.28.0",
-        "@typescript-eslint/types": "5.28.0",
-        "@typescript-eslint/typescript-estree": "5.28.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.28.0.tgz",
-      "integrity": "sha512-BtfP1vCor8cWacovzzPFOoeW4kBQxzmhxGoOpt0v1SFvG+nJ0cWaVdJk7cky1ArTcFHHKNIxyo2LLr3oNkSuXA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
+      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
       "dependencies": {
-        "@typescript-eslint/types": "5.28.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "6.1.0",
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5717,11 +5266,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
-    },
     "node_modules/dataloader": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
@@ -5869,9 +5413,9 @@
       }
     },
     "node_modules/default-browser/node_modules/execa": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-      "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",
@@ -6281,45 +5825,47 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
-      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.9.2",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.1.0",
+        "@eslint/js": "8.44.0",
+        "@humanwhocodes/config-array": "^0.11.10",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.6.0",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^6.0.1",
-        "globals": "^13.15.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -6332,10 +5878,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6344,68 +5889,41 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
       },
       "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
       }
     },
     "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dependencies": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
+        "estraverse": "^5.2.0"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -6413,24 +5931,83 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
       "engines": {
-        "node": ">=4.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/esm": {
@@ -6480,14 +6057,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -6499,19 +6068,10 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6658,9 +6218,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -6863,9 +6423,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -6961,11 +6521,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -12877,15 +12432,14 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -12976,9 +12530,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
         "node": ">=6"
       }
@@ -13340,17 +12894,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/registry-auth-token": {
@@ -14458,7 +14001,7 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -14674,27 +14217,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/tsutils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -14846,11 +14368,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -15045,26 +14562,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/xss": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
-      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/xss/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -15245,14 +14742,6 @@
         "@apollo/utils.logger": "^2.0.0"
       }
     },
-    "@apollo/server-plugin-landing-page-graphql-playground": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-plugin-landing-page-graphql-playground/-/server-plugin-landing-page-graphql-playground-4.0.1.tgz",
-      "integrity": "sha512-tWhQzD7DtiTO/wfbGvasryz7eJSuEh9XJHgRTMZI7+Wu/omylG5gH6K6ksg1Vccg8/Xuglfi2f1M5Nm/IlBBGw==",
-      "requires": {
-        "@apollographql/graphql-playground-html": "1.6.29"
-      }
-    },
     "@apollo/subgraph": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.5.1.tgz",
@@ -15359,14 +14848,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.0.tgz",
       "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ=="
-    },
-    "@apollographql/graphql-playground-html": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-      "requires": {
-        "xss": "^1.0.8"
-      }
     },
     "@aws-crypto/crc32": {
       "version": "3.0.0",
@@ -16401,19 +15882,19 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.1.tgz",
-      "integrity": "sha512-O7x6dMstWLn2ktjcoiNLDkAGG2EjveHL+Vvc+n0fXumkJYAcSqcVYKtwDU+hDZ0uDUsnUagSYaZrOLAYE8un1A=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw=="
     },
     "@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
+      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
-        "globals": "^13.15.0",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -16462,13 +15943,13 @@
       "requires": {}
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "@humanwhocodes/module-importer": {
@@ -17050,17 +16531,16 @@
       }
     },
     "@pocket-tools/eslint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/eslint-config/-/eslint-config-2.0.0.tgz",
-      "integrity": "sha512-F9Pxtnla/wN015/T/4uGMV8j+nUATpUZ6yrcNci6QUIoWijUTYhx0iil0lFiTPZ8Q3kyKaV64GDhEi+pAc0XTg==",
-      "dev": true,
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/eslint-config/-/eslint-config-2.1.7.tgz",
+      "integrity": "sha512-NXwPidPMa5rfYyAXdAQH1ooZ8IZIK3vSLpdGmvX5d4XEWdrf69vdpBcdHKn7GzBrAi2qltOpXc9kmrybTQ2HNg==",
       "requires": {
-        "@typescript-eslint/eslint-plugin": "5.28.0",
-        "@typescript-eslint/parser": "5.28.0",
-        "eslint": "8.18.0",
-        "eslint-config-prettier": "8.5.0",
-        "eslint-plugin-prettier": "4.0.0",
-        "prettier": "2.7.1"
+        "@typescript-eslint/eslint-plugin": "6.1.0",
+        "@typescript-eslint/parser": "6.1.0",
+        "eslint": "8.45.0",
+        "eslint-config-prettier": "8.8.0",
+        "eslint-plugin-prettier": "5.0.0",
+        "prettier": "3.0.0"
       }
     },
     "@pocket-tools/ts-logger": {
@@ -17078,256 +16558,6 @@
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "winston": "^3.9.0"
-      },
-      "dependencies": {
-        "@eslint/eslintrc": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-          "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
-          "requires": {
-            "ajv": "^6.12.4",
-            "debug": "^4.3.2",
-            "espree": "^9.6.0",
-            "globals": "^13.19.0",
-            "ignore": "^5.2.0",
-            "import-fresh": "^3.2.1",
-            "js-yaml": "^4.1.0",
-            "minimatch": "^3.1.2",
-            "strip-json-comments": "^3.1.1"
-          }
-        },
-        "@humanwhocodes/config-array": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-          "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
-          "requires": {
-            "@humanwhocodes/object-schema": "^1.2.1",
-            "debug": "^4.1.1",
-            "minimatch": "^3.0.5"
-          }
-        },
-        "@pocket-tools/eslint-config": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/@pocket-tools/eslint-config/-/eslint-config-2.1.7.tgz",
-          "integrity": "sha512-NXwPidPMa5rfYyAXdAQH1ooZ8IZIK3vSLpdGmvX5d4XEWdrf69vdpBcdHKn7GzBrAi2qltOpXc9kmrybTQ2HNg==",
-          "requires": {
-            "@typescript-eslint/eslint-plugin": "6.1.0",
-            "@typescript-eslint/parser": "6.1.0",
-            "eslint": "8.45.0",
-            "eslint-config-prettier": "8.8.0",
-            "eslint-plugin-prettier": "5.0.0",
-            "prettier": "3.0.0"
-          }
-        },
-        "@typescript-eslint/eslint-plugin": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
-          "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
-          "requires": {
-            "@eslint-community/regexpp": "^4.5.1",
-            "@typescript-eslint/scope-manager": "6.1.0",
-            "@typescript-eslint/type-utils": "6.1.0",
-            "@typescript-eslint/utils": "6.1.0",
-            "@typescript-eslint/visitor-keys": "6.1.0",
-            "debug": "^4.3.4",
-            "graphemer": "^1.4.0",
-            "ignore": "^5.2.4",
-            "natural-compare": "^1.4.0",
-            "natural-compare-lite": "^1.4.0",
-            "semver": "^7.5.4",
-            "ts-api-utils": "^1.0.1"
-          }
-        },
-        "@typescript-eslint/parser": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
-          "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
-          "requires": {
-            "@typescript-eslint/scope-manager": "6.1.0",
-            "@typescript-eslint/types": "6.1.0",
-            "@typescript-eslint/typescript-estree": "6.1.0",
-            "@typescript-eslint/visitor-keys": "6.1.0",
-            "debug": "^4.3.4"
-          }
-        },
-        "@typescript-eslint/scope-manager": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
-          "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
-          "requires": {
-            "@typescript-eslint/types": "6.1.0",
-            "@typescript-eslint/visitor-keys": "6.1.0"
-          }
-        },
-        "@typescript-eslint/type-utils": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
-          "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
-          "requires": {
-            "@typescript-eslint/typescript-estree": "6.1.0",
-            "@typescript-eslint/utils": "6.1.0",
-            "debug": "^4.3.4",
-            "ts-api-utils": "^1.0.1"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
-          "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ=="
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
-          "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
-          "requires": {
-            "@typescript-eslint/types": "6.1.0",
-            "@typescript-eslint/visitor-keys": "6.1.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.5.4",
-            "ts-api-utils": "^1.0.1"
-          }
-        },
-        "@typescript-eslint/utils": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
-          "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
-          "requires": {
-            "@eslint-community/eslint-utils": "^4.4.0",
-            "@types/json-schema": "^7.0.12",
-            "@types/semver": "^7.5.0",
-            "@typescript-eslint/scope-manager": "6.1.0",
-            "@typescript-eslint/types": "6.1.0",
-            "@typescript-eslint/typescript-estree": "6.1.0",
-            "semver": "^7.5.4"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
-          "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
-          "requires": {
-            "@typescript-eslint/types": "6.1.0",
-            "eslint-visitor-keys": "^3.4.1"
-          }
-        },
-        "eslint": {
-          "version": "8.45.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
-          "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
-          "requires": {
-            "@eslint-community/eslint-utils": "^4.2.0",
-            "@eslint-community/regexpp": "^4.4.0",
-            "@eslint/eslintrc": "^2.1.0",
-            "@eslint/js": "8.44.0",
-            "@humanwhocodes/config-array": "^0.11.10",
-            "@humanwhocodes/module-importer": "^1.0.1",
-            "@nodelib/fs.walk": "^1.2.8",
-            "ajv": "^6.10.0",
-            "chalk": "^4.0.0",
-            "cross-spawn": "^7.0.2",
-            "debug": "^4.3.2",
-            "doctrine": "^3.0.0",
-            "escape-string-regexp": "^4.0.0",
-            "eslint-scope": "^7.2.0",
-            "eslint-visitor-keys": "^3.4.1",
-            "espree": "^9.6.0",
-            "esquery": "^1.4.2",
-            "esutils": "^2.0.2",
-            "fast-deep-equal": "^3.1.3",
-            "file-entry-cache": "^6.0.1",
-            "find-up": "^5.0.0",
-            "glob-parent": "^6.0.2",
-            "globals": "^13.19.0",
-            "graphemer": "^1.4.0",
-            "ignore": "^5.2.0",
-            "imurmurhash": "^0.1.4",
-            "is-glob": "^4.0.0",
-            "is-path-inside": "^3.0.3",
-            "js-yaml": "^4.1.0",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.4.1",
-            "lodash.merge": "^4.6.2",
-            "minimatch": "^3.1.2",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.9.3",
-            "strip-ansi": "^6.0.1",
-            "text-table": "^0.2.0"
-          }
-        },
-        "eslint-config-prettier": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-          "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-          "requires": {}
-        },
-        "eslint-plugin-prettier": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-          "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
-          "requires": {
-            "prettier-linter-helpers": "^1.0.0",
-            "synckit": "^0.8.5"
-          }
-        },
-        "eslint-scope": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
-          "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^5.2.0"
-          }
-        },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "prettier": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-          "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g=="
-        },
-        "yocto-queue": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-        }
       }
     },
     "@pocket-tools/tsconfig": {
@@ -18527,98 +17757,96 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.28.0.tgz",
-      "integrity": "sha512-DXVU6Cg29H2M6EybqSg2A+x8DgO9TCUBRp4QEXQHJceLS7ogVDP0g3Lkg/SZCqcvkAP/RruuQqK0gdlkgmhSUA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
+      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
       "requires": {
-        "@typescript-eslint/scope-manager": "5.28.0",
-        "@typescript-eslint/type-utils": "5.28.0",
-        "@typescript-eslint/utils": "5.28.0",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/type-utils": "6.1.0",
+        "@typescript-eslint/utils": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.2.0",
-        "regexpp": "^3.2.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.28.0.tgz",
-      "integrity": "sha512-ekqoNRNK1lAcKhZESN/PdpVsWbP9jtiNqzFWkp/yAUdZvJalw2heCYuqRmM5eUJSIYEkgq5sGOjq+ZqsLMjtRA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
+      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
       "requires": {
-        "@typescript-eslint/scope-manager": "5.28.0",
-        "@typescript-eslint/types": "5.28.0",
-        "@typescript-eslint/typescript-estree": "5.28.0",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.28.0.tgz",
-      "integrity": "sha512-LeBLTqF/he1Z+boRhSqnso6YrzcKMTQ8bO/YKEe+6+O/JGof9M0g3IJlIsqfrK/6K03MlFIlycbf1uQR1IjE+w==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
+      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
       "requires": {
-        "@typescript-eslint/types": "5.28.0",
-        "@typescript-eslint/visitor-keys": "5.28.0"
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.28.0.tgz",
-      "integrity": "sha512-SyKjKh4CXPglueyC6ceAFytjYWMoPHMswPQae236zqe1YbhvCVQyIawesYywGiu98L9DwrxsBN69vGIVxJ4mQQ==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
+      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
       "requires": {
-        "@typescript-eslint/utils": "5.28.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/utils": "6.1.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.28.0.tgz",
-      "integrity": "sha512-2OOm8ZTOQxqkPbf+DAo8oc16sDlVR5owgJfKheBkxBKg1vAfw2JsSofH9+16VPlN9PWtv8Wzhklkqw3k/zCVxA==",
-      "dev": true
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.28.0.tgz",
-      "integrity": "sha512-9GX+GfpV+F4hdTtYc6OV9ZkyYilGXPmQpm6AThInpBmKJEyRSIjORJd1G9+bknb7OTFYL+Vd4FBJAO6T78OVqA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
+      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
       "requires": {
-        "@typescript-eslint/types": "5.28.0",
-        "@typescript-eslint/visitor-keys": "5.28.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.28.0.tgz",
-      "integrity": "sha512-E60N5L0fjv7iPJV3UGc4EC+A3Lcj4jle9zzR0gW7vXhflO7/J29kwiTGITA2RlrmPokKiZbBy2DgaclCaEUs6g==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
+      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
       "requires": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.28.0",
-        "@typescript-eslint/types": "5.28.0",
-        "@typescript-eslint/typescript-estree": "5.28.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "semver": "^7.5.4"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.28.0.tgz",
-      "integrity": "sha512-BtfP1vCor8cWacovzzPFOoeW4kBQxzmhxGoOpt0v1SFvG+nJ0cWaVdJk7cky1ArTcFHHKNIxyo2LLr3oNkSuXA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
+      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
       "requires": {
-        "@typescript-eslint/types": "5.28.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "6.1.0",
+        "eslint-visitor-keys": "^3.4.1"
       }
     },
     "abbrev": {
@@ -19451,11 +18679,6 @@
         }
       }
     },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
-    },
     "dataloader": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
@@ -19545,9 +18768,9 @@
       },
       "dependencies": {
         "execa": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-          "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
           "requires": {
             "cross-spawn": "^7.0.3",
             "get-stream": "^6.0.1",
@@ -19822,108 +19045,117 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "eslint": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
-      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "requires": {
-        "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.9.2",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.1.0",
+        "@eslint/js": "8.44.0",
+        "@humanwhocodes/config-array": "^0.11.10",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.6.0",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^6.0.1",
-        "globals": "^13.15.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "dependencies": {
-        "eslint-scope": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
           "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^5.2.0"
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
           }
         },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "yocto-queue": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "requires": {}
     },
     "eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "requires": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       }
     },
     "eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "requires": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      }
-    },
-    "eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "requires": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
-        }
+        "estraverse": "^5.2.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw=="
     },
     "esm": {
       "version": "3.2.25",
@@ -19951,13 +19183,6 @@
       "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "requires": {
         "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        }
       }
     },
     "esrecurse": {
@@ -19966,20 +19191,12 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "requires": {
         "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        }
       }
     },
     "estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -20098,9 +19315,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
     "fast-glob": {
       "version": "3.3.1",
@@ -20257,9 +19474,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "fn.name": {
       "version": "1.1.0",
@@ -20333,11 +19550,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -24348,10 +23560,9 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -24419,9 +23630,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "pure-rand": {
       "version": "6.0.2",
@@ -24663,11 +23874,6 @@
       "requires": {
         "redis-errors": "^1.0.0"
       }
-    },
-    "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
     },
     "registry-auth-token": {
       "version": "5.0.2",
@@ -25460,7 +24666,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "through": {
       "version": "2.3.8",
@@ -25591,23 +24797,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
-    "tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
-      }
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -25707,11 +24896,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -25866,22 +25050,6 @@
       "requires": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
-      }
-    },
-    "xss": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
-      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
-      "requires": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/Pocket/annotations-api#readme",
   "dependencies": {
     "@apollo/server": "4.9.0",
-    "@apollo/server-plugin-landing-page-graphql-playground": "4.0.1",
     "@apollo/subgraph": "2.5.1",
     "@aws-sdk/client-dynamodb": "3.379.1",
     "@aws-sdk/client-sqs": "3.379.1",
@@ -48,7 +47,7 @@
     "nanoid": "3.3.6"
   },
   "devDependencies": {
-    "@pocket-tools/eslint-config": "2.0.0",
+    "@pocket-tools/eslint-config": "2.1.7",
     "@pocket-tools/tsconfig": "2.0.1",
     "@types/chai": "4.3.5",
     "@types/chance": "1.1.3",

--- a/src/context.ts
+++ b/src/context.ts
@@ -35,7 +35,7 @@ export class ContextManager implements IContext {
       request: express.Request;
       db: { readClient: Knex; writeClient: Knex };
       dynamoClient: DynamoDBClient;
-    }
+    },
   ) {
     this.db = config.db;
     this.config = config;
@@ -55,7 +55,7 @@ export class ContextManager implements IContext {
 
     if (!userId) {
       throw new AuthenticationError(
-        'You must be logged in to use this service'
+        'You must be logged in to use this service',
       );
     }
 
@@ -71,7 +71,7 @@ export class ContextManager implements IContext {
   get notesService(): NotesDataService {
     if (!this.isPremium) {
       throw new ForbiddenError(
-        'Premium account required to access this feature'
+        'Premium account required to access this feature',
       );
     }
     return new NotesDataService(this.dynamoClient, this.userId);

--- a/src/dataservices/dataloaders.spec.ts
+++ b/src/dataservices/dataloaders.spec.ts
@@ -14,7 +14,7 @@ describe('dataloaders', () => {
     it('reorders data by highlightId', () => {
       const result = orderAndMapNotes(
         ['hij', 'def', 'abc', 'hij'],
-        mockNotesResponse
+        mockNotesResponse,
       );
       const expected = [
         { highlightId: 'hij', text: 'yummy', _createdAt: 1, _updatedAt: 1 },

--- a/src/dataservices/dataloaders.ts
+++ b/src/dataservices/dataloaders.ts
@@ -8,11 +8,12 @@ import { IContext } from '../context';
  * called when the context is constructed to create a new dataloader
  * instance for each request.
  * @param client DynamoDB Client to use inside NotesDataService
+ * @param context
  * @returns DataLoader which loads HighlightNote objects by highlightId string key
  */
 export function createNotesLoader(
   client: DynamoDBClient,
-  context: IContext
+  context: IContext,
 ): DataLoader<string, HighlightNote | undefined> {
   return new DataLoader<string, HighlightNote | undefined>(
     async (keys: string[]) => {
@@ -21,7 +22,7 @@ export function createNotesLoader(
       // we need these to be explicitly included, even if undefined,
       // so that the response has the same expected length and order
       return orderAndMapNotes(keys, notes);
-    }
+    },
   );
 }
 
@@ -35,7 +36,7 @@ export function createNotesLoader(
  */
 export function orderAndMapNotes(
   keys: string[],
-  notesResponse: HighlightNote[]
+  notesResponse: HighlightNote[],
 ): Array<HighlightNote | undefined> {
   const noteKeyMap = notesResponse.reduce((keyMap, currentNote) => {
     keyMap[currentNote.highlightId] = currentNote;

--- a/src/dataservices/highlights.ts
+++ b/src/dataservices/highlights.ts
@@ -19,7 +19,7 @@ export class HighlightsDataService {
   private readonly savedItemService: SavedItem;
 
   constructor(
-    private context: Pick<IContext, 'db' | 'userId' | 'isPremium' | 'apiId'>
+    private context: Pick<IContext, 'db' | 'userId' | 'isPremium' | 'apiId'>,
   ) {
     this.userId = context.userId;
     this.readDb = context.db.readClient;
@@ -43,7 +43,7 @@ export class HighlightsDataService {
   }
 
   private async highlightsCountByItemIds(
-    itemIds: number[]
+    itemIds: number[],
   ): Promise<{ [itemId: string]: number }> {
     const result = await this.readDb<HighlightEntity>('user_annotations')
       .select('item_id')
@@ -96,11 +96,11 @@ export class HighlightsDataService {
     // Add the two counts together to get the desired totals
     const totalDesiredCounts = sumByKey(currentCounts, additionalCounts);
     const exceedsLimit = Object.entries(totalDesiredCounts).find(
-      ([_, count]) => count > config.basicHighlightLimit
+      ([_, count]) => count > config.basicHighlightLimit,
     );
     if (exceedsLimit != null) {
       throw new UserInputError(
-        `Too many highlights for itemId: ${exceedsLimit[0]}`
+        `Too many highlights for itemId: ${exceedsLimit[0]}`,
       );
     }
   }
@@ -126,14 +126,14 @@ export class HighlightsDataService {
     }
 
     const formattedHighlights = highlightInput.map((highlight) =>
-      this.toDbEntity(highlight)
+      this.toDbEntity(highlight),
     );
 
     const rows = await this.writeDb.transaction(
       async (trx: Knex.Transaction) => {
         // Insert into the db
         await trx<HighlightEntity>('user_annotations').insert(
-          formattedHighlights
+          formattedHighlights,
         );
 
         const updateDate = new Date();
@@ -144,9 +144,9 @@ export class HighlightsDataService {
             await this.savedItemService.markUpdate(
               input.itemId,
               updateDate,
-              trx
+              trx,
             );
-          })
+          }),
         );
         // Update users_meta table
         await this.usersMetaService.logAnnotationMutation(updateDate, trx);
@@ -156,9 +156,9 @@ export class HighlightsDataService {
           .select()
           .whereIn(
             'annotation_id',
-            formattedHighlights.map((highlight) => highlight.annotation_id)
+            formattedHighlights.map((highlight) => highlight.annotation_id),
           );
-      }
+      },
     );
 
     return rows.map(this.toGraphql);
@@ -240,7 +240,7 @@ export class HighlightsDataService {
       await this.savedItemService.markUpdate(
         annotation.item_id.toString(),
         updateDate,
-        trx
+        trx,
       );
       // Update users_meta table
       await this.usersMetaService.logAnnotationMutation(updateDate, trx);
@@ -258,7 +258,7 @@ export class HighlightsDataService {
    */
   public async deleteByAnnotationIds(
     annotationIds: string[],
-    requestId: string
+    requestId: string,
   ) {
     for (const id of annotationIds) {
       try {
@@ -269,7 +269,7 @@ export class HighlightsDataService {
 
         serverLogger.info(
           `deleted row from table user_annotations for ` +
-            `user: ${this.userId} and annotation_id: ${id}; requestId: ${requestId}`
+            `user: ${this.userId} and annotation_id: ${id}; requestId: ${requestId}`,
         );
         await setTimeout(config.batchDelete.deleteDelayInMilliSec);
       } catch (error) {
@@ -280,7 +280,7 @@ export class HighlightsDataService {
           'Annotations',
           this.userId,
           requestId,
-          id
+          id,
         );
       }
     }
@@ -317,7 +317,7 @@ export class HighlightsDataService {
    */
   private toDbEntity(
     input: HighlightInput,
-    id?: string
+    id?: string,
   ): Omit<HighlightEntity, 'created_at' | 'updated_at'> {
     return {
       annotation_id: id ?? uuid(),

--- a/src/dataservices/notes.ts
+++ b/src/dataservices/notes.ts
@@ -28,7 +28,10 @@ export class NotesDataService {
   public dynamo: DynamoDBDocumentClient;
   private table = config.dynamoDb.notesTable;
 
-  constructor(private client: DynamoDBClient, private userId: string) {
+  constructor(
+    private client: DynamoDBClient,
+    private userId: string,
+  ) {
     const dynamoClientConfig: DynamoDBClientConfig = {
       region: config.aws.region,
     };
@@ -113,11 +116,11 @@ export class NotesDataService {
         await backoff(tries, config.aws.maxBackoff);
       }
       const response: BatchGetCommandOutput = await this.dynamo.send(
-        batchItemCommand
+        batchItemCommand,
       );
       if (response.Responses) {
         itemResults.push(
-          ...(response.Responses?.[this.table.name] as HighlightNoteEntity[])
+          ...(response.Responses?.[this.table.name] as HighlightNoteEntity[]),
         );
       }
       // Increment tries for backoff, and reset unprocessed key list
@@ -147,7 +150,7 @@ export class NotesDataService {
       return this.toGraphQl(noteEntity as HighlightNoteEntity);
     }
     throw new Error(
-      `Unable to create highlight note (dynamoDB request ID = ${response?.$metadata.requestId}`
+      `Unable to create highlight note (dynamoDB request ID = ${response?.$metadata.requestId}`,
     );
   }
 
@@ -197,7 +200,7 @@ export class NotesDataService {
         await backoff(tries, config.aws.maxBackoff);
       }
       const response: BatchWriteCommandOutput = await this.dynamo.send(
-        batchWriteCommand
+        batchWriteCommand,
       );
       // Increment tries for backoff, and reset unprocessed writes list
       tries += 1;
@@ -219,7 +222,7 @@ export class NotesDataService {
    * @returns Array of notes corresponding to GraphQL object
    */
   public async batchCreate(
-    notes: { id: string; text: string }[]
+    notes: { id: string; text: string }[],
   ): Promise<HighlightNote[]> {
     const noteEntities = notes.map((note) => this.toEntity(note.id, note.text));
     const notePutRequests = noteEntities.map((note) => {
@@ -243,7 +246,7 @@ export class NotesDataService {
     });
 
     const response: DeleteCommandOutput = await this.dynamo.send(
-      deleteItemCommand
+      deleteItemCommand,
     );
     if (response.Attributes == null) {
       throw new NotFoundError('Note does not exist on highlight');
@@ -277,7 +280,7 @@ export class NotesDataService {
     // more values to query for
     while (lastEvaluatedKey != null) {
       const highlightResult: QueryCommandOutput = await this.client.send(
-        new QueryCommand(queryCommandInput)
+        new QueryCommand(queryCommandInput),
       );
       if (highlightResult.Items?.length > 0) {
         const deleteRequests = highlightResult.Items.map((res) => ({

--- a/src/dataservices/savedItem.ts
+++ b/src/dataservices/savedItem.ts
@@ -21,7 +21,7 @@ export class SavedItem {
   public async markUpdate(
     itemId: string,
     date: Date,
-    trx: Knex.Transaction
+    trx: Knex.Transaction,
   ): Promise<void> {
     await trx('list')
       .update({

--- a/src/dataservices/usersMeta.ts
+++ b/src/dataservices/usersMeta.ts
@@ -29,13 +29,13 @@ export class UsersMeta {
    */
   public async logAnnotationMutation(
     timestamp: Date,
-    trx: Knex.Transaction
+    trx: Knex.Transaction,
   ): Promise<void> {
     const propertyCode = UsersMeta.propertiesMap.account;
     // The table should be unique on property:user_id for annotations log
     await this.deleteByProperty(propertyCode).transacting(trx);
     await this.insertTimestampByProperty(propertyCode, timestamp).transacting(
-      trx
+      trx,
     );
   }
 
@@ -55,7 +55,7 @@ export class UsersMeta {
    */
   private insertTimestampByProperty(
     property: number,
-    timestamp: Date
+    timestamp: Date,
   ): Knex.QueryBuilder {
     return this.db.insert({
       user_id: this.userId,

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -13,10 +13,10 @@ export const resolvers = {
     annotations: async (
       parent: SavedItem,
       _,
-      context: IContext
+      context: IContext,
     ): Promise<SavedItemAnnotations> => {
       const highlights = await new HighlightsDataService(context).getByItemId(
-        parent.id
+        parent.id,
       );
       return { highlights };
     },
@@ -25,7 +25,7 @@ export const resolvers = {
     note: async (
       parent: Highlight,
       _,
-      context: IContext
+      context: IContext,
     ): Promise<HighlightNote | undefined> => {
       return context.dataLoaders.noteByHighlightId.load(parent.id);
     },
@@ -34,17 +34,23 @@ export const resolvers = {
     createSavedItemHighlights: async (
       _,
       args: { input: HighlightInput[] },
-      context: IContext
+      context: IContext,
     ): Promise<Highlight[]> => {
       const highlights = await new HighlightsDataService(context).create(
-        args.input
+        args.input,
       );
-      const noteData = args.input.reduce((result, highlightInput, index) => {
-        if (highlightInput.note) {
-          result.push({ id: highlights[index].id, text: highlightInput.note });
-        }
-        return result;
-      }, [] as { id: string; text: string }[]);
+      const noteData = args.input.reduce(
+        (result, highlightInput, index) => {
+          if (highlightInput.note) {
+            result.push({
+              id: highlights[index].id,
+              text: highlightInput.note,
+            });
+          }
+          return result;
+        },
+        [] as { id: string; text: string }[],
+      );
       let notes: HighlightNote[];
       if (noteData.length > 0) {
         notes = await context.notesService.batchCreate(noteData);
@@ -59,7 +65,7 @@ export const resolvers = {
     updateSavedItemHighlight: async (
       _: any,
       params: { id: string; input: HighlightInput },
-      context: IContext
+      context: IContext,
     ): Promise<Highlight> => {
       const dataService = new HighlightsDataService(context);
       await dataService.update(params.id, params.input);
@@ -68,17 +74,17 @@ export const resolvers = {
     deleteSavedItemHighlight: async (
       _,
       args,
-      context: IContext
+      context: IContext,
     ): Promise<string> => {
       const highlightId = await new HighlightsDataService(context).delete(
-        args.id
+        args.id,
       );
       return highlightId;
     },
     createSavedItemHighlightNote: async (
       _,
       args: { id: string; input: string },
-      context: IContext
+      context: IContext,
     ): Promise<HighlightNote> => {
       const dataService = new HighlightsDataService(context);
       await dataService.getById(args.id);
@@ -87,7 +93,7 @@ export const resolvers = {
     updateSavedItemHighlightNote: async (
       _,
       args: { id: string; input: string },
-      context: IContext
+      context: IContext,
     ): Promise<HighlightNote> => {
       const dataService = new HighlightsDataService(context);
       await dataService.getById(args.id);
@@ -96,7 +102,7 @@ export const resolvers = {
     deleteSavedItemHighlightNote: async (
       _,
       args,
-      context: IContext
+      context: IContext,
     ): Promise<string> => {
       const dataService = await new HighlightsDataService(context);
       await dataService.delete(args.id);

--- a/src/server/aws/batchDeleteHandler.spec.ts
+++ b/src/server/aws/batchDeleteHandler.spec.ts
@@ -55,7 +55,7 @@ describe('batchDeleteHandler', () => {
     expect(
       sentryStub.calledOnceWithExactly(error, {
         level: Sentry.Severity.Critical,
-      })
+      }),
     ).toBe(true);
     expect(serverLoggerStub.callCount).toEqual(1);
     expect(scheduleStub.calledOnceWithExactly(300000)).toBe(true);
@@ -72,7 +72,10 @@ describe('batchDeleteHandler', () => {
           .resolves({ Messages: [{ Body: JSON.stringify(fakeMessageBody) }] });
         await batchDeleteHandler.pollQueue();
         expect(
-          deleteStub.calledOnceWithExactly(['1', '2', '3', '4', '5'], 'abc-123')
+          deleteStub.calledOnceWithExactly(
+            ['1', '2', '3', '4', '5'],
+            'abc-123',
+          ),
         ).toBe(true);
       });
       it('schedules polling another message after a delay', async () => {
@@ -98,7 +101,7 @@ describe('batchDeleteHandler', () => {
           new DeleteMessageCommand({
             QueueUrl: config.aws.sqs.annotationsDeleteQueue.url,
             ReceiptHandle: undefined,
-          }).input
+          }).input,
         );
       });
       it('does not delete if message was unsuccessfully processed', async () => {

--- a/src/server/aws/batchDeleteHandler.ts
+++ b/src/server/aws/batchDeleteHandler.ts
@@ -41,7 +41,10 @@ export class BatchDeleteHandler {
    * @param pollOnInit whether to start polling when the class is
    * instantiated, primarily for testing (default=true);
    */
-  constructor(public readonly emitter: EventEmitter, pollOnInit = true) {
+  constructor(
+    public readonly emitter: EventEmitter,
+    pollOnInit = true,
+  ) {
     this.sqsClient = new SQSClient({
       region: config.aws.region,
       endpoint: config.aws.endpoint,
@@ -49,7 +52,7 @@ export class BatchDeleteHandler {
     });
     emitter.on(
       BatchDeleteHandler.eventName,
-      async () => await this.pollQueue()
+      async () => await this.pollQueue(),
     );
     // Start the polling by emitting an initial event
     if (pollOnInit) {
@@ -164,12 +167,12 @@ export class BatchDeleteHandler {
       // Schedule next message poll
       await this.scheduleNextPoll(
         config.aws.sqs.annotationsDeleteQueue.afterMessagePollIntervalSeconds *
-          1000
+          1000,
       );
     } else {
       // If no messages were found, schedule another poll after a short time
       await this.scheduleNextPoll(
-        config.aws.sqs.annotationsDeleteQueue.defaultPollIntervalSeconds * 1000
+        config.aws.sqs.annotationsDeleteQueue.defaultPollIntervalSeconds * 1000,
       );
     }
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,6 @@ import { ApolloServer } from '@apollo/server';
 import { expressMiddleware } from '@apollo/server/express4';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
-import { ApolloServerPluginLandingPageGraphQLPlayground } from '@apollo/server-plugin-landing-page-graphql-playground';
 import {
   ApolloServerPluginLandingPageDisabled,
   ApolloServerPluginInlineTraceDisabled,
@@ -14,6 +13,7 @@ import {
 } from '@apollo/server/plugin/disabled';
 import { ApolloServerPluginInlineTrace } from '@apollo/server/plugin/inlineTrace';
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
+import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default';
 
 import typeDefs from '../typeDefs';
 import { resolvers } from '../resolvers';
@@ -47,7 +47,7 @@ export async function startServer(port: number): Promise<{
     // JSON parser to enable POST body with JSON
     express.json(),
     // JSON parser to enable POST body with JSON
-    setMorgan(serverLogger)
+    setMorgan(serverLogger),
   );
   app.use('/queueDelete', queueDeleteRouter);
 
@@ -60,7 +60,7 @@ export async function startServer(port: number): Promise<{
     ApolloServerPluginInlineTrace(),
   ];
   const nonProdPlugins = [
-    ApolloServerPluginLandingPageGraphQLPlayground(),
+    ApolloServerPluginLandingPageLocalDefault(),
     ApolloServerPluginInlineTraceDisabled(),
     ApolloServerPluginUsageReportingDisabled(),
   ];
@@ -85,7 +85,7 @@ export async function startServer(port: number): Promise<{
     cors<cors.CorsRequest>(),
     expressMiddleware<IContext>(server, {
       context: getContext,
-    })
+    }),
   );
 
   await new Promise<void>((resolve) => httpServer.listen({ port }, resolve));

--- a/src/server/routes/helper.ts
+++ b/src/server/routes/helper.ts
@@ -4,7 +4,7 @@ import { serverLogger } from '../';
 export const successCallback = (
   dataType: string,
   userId: string,
-  traceId: string
+  traceId: string,
 ) => {
   const successMessage = `BatchDelete: ${dataType} deletion completed for userId=${userId}, traceId=${traceId}`;
   serverLogger.info(successMessage);
@@ -16,7 +16,7 @@ export const failCallback = (
   dataType: string,
   userId: string,
   traceId: string,
-  annotationId?: string
+  annotationId?: string,
 ) => {
   let failMessage = `${module}: Error = Failed to delete ${dataType} for userId=${userId}, traceId=${traceId}`;
   if (annotationId) {

--- a/src/server/routes/queueDelete.integration.ts
+++ b/src/server/routes/queueDelete.integration.ts
@@ -59,7 +59,7 @@ describe('/queueDelete', () => {
       sqsSendMock?.restore();
     });
     beforeEach(
-      () => (sqsSendMock = sinon.stub(SQS.prototype, 'send').resolves())
+      () => (sqsSendMock = sinon.stub(SQS.prototype, 'send').resolves()),
     );
     afterEach(() => sqsSendMock.restore());
     it('sends batches of messages to sqs', async () => {
@@ -86,17 +86,17 @@ describe('/queueDelete', () => {
       await enqueueAnnotationIds(
         data as SqsMessage,
         highlightsDataService,
-        '123'
+        '123',
       );
 
       expect(sqsSendMock.callCount).to.equal(2);
       // No exceptions
       expect(sentrySpy.callCount).to.equal(0);
       const firstMessage = JSON.parse(
-        sqsSendMock.getCall(0).args[0].input.Entries[0].MessageBody
+        sqsSendMock.getCall(0).args[0].input.Entries[0].MessageBody,
       );
       const secondMessage = JSON.parse(
-        sqsSendMock.getCall(1).args[0].input.Entries[0].MessageBody
+        sqsSendMock.getCall(1).args[0].input.Entries[0].MessageBody,
       );
       expect(firstMessage).to.shallowDeepEqual({
         ...data,
@@ -149,7 +149,7 @@ describe('/queueDelete', () => {
       await enqueueAnnotationIds(
         data as SqsMessage,
         highlightsDataService,
-        '123'
+        '123',
       );
 
       // Two calls made

--- a/src/server/routes/queueDelete.ts
+++ b/src/server/routes/queueDelete.ts
@@ -58,7 +58,7 @@ router.post(
       .clearUserData()
       .then(() => successCallback('Notes', userId, requestId))
       .catch((error) =>
-        failCallback('queueDelete', error, 'Notes', userId, requestId)
+        failCallback('queueDelete', error, 'Notes', userId, requestId),
       );
 
     const highlightDataService = new HighlightsDataService({
@@ -77,7 +77,7 @@ router.post(
       status: 'OK',
       message: `QueueDelete: Enqueued items for User ID: ${req.body.userId} (requestId='${requestId}')`,
     });
-  }
+  },
 );
 
 /**
@@ -93,7 +93,7 @@ router.post(
 export async function enqueueAnnotationIds(
   data: Omit<SqsMessage, 'annotationIds'>,
   highlightDataService: HighlightsDataService,
-  requestId: string
+  requestId: string,
 ): Promise<void> {
   const { userId, email, isPremium } = data;
   const limit = config.queueDelete.queryLimit;
@@ -117,7 +117,7 @@ export async function enqueueAnnotationIds(
           isPremium,
           annotationIds: nextChunk.value,
           traceId: nanoid(),
-        })
+        }),
       );
 
       if (sqsEntries.length === config.aws.sqs.batchSize) {
@@ -141,13 +141,13 @@ export async function enqueueAnnotationIds(
       // Handle logging individual errors as the promises are resolved
       return sqs.send(command).catch((err) => {
         const message = `QueueDelete: Error - Failed to enqueue annotationIds for userId: ${userId} (command=\n${JSON.stringify(
-          command
+          command,
         )})`;
         Sentry.addBreadcrumb({ message });
         Sentry.captureException(err);
         serverLogger.error(message);
       });
-    })
+    }),
   );
 }
 
@@ -157,7 +157,7 @@ export async function enqueueAnnotationIds(
  * @param entries
  */
 function buildSqsCommand(
-  entries: SendMessageBatchRequestEntry[]
+  entries: SendMessageBatchRequestEntry[],
 ): SendMessageBatchCommand {
   const command = new SendMessageBatchCommand({
     Entries: entries,

--- a/src/server/routes/validator.ts
+++ b/src/server/routes/validator.ts
@@ -4,7 +4,7 @@ import { validationResult } from 'express-validator';
 export function validate(
   req: express.Request,
   res: express.Response,
-  next: express.NextFunction
+  next: express.NextFunction,
 ) {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {

--- a/src/test/clearUserData/highlights.integration.ts
+++ b/src/test/clearUserData/highlights.integration.ts
@@ -16,10 +16,10 @@ describe('clearUserData for Highlights data', () => {
     batchDeleteDelay = config.batchDelete.deleteDelayInMilliSec;
     config.batchDelete.deleteDelayInMilliSec = 1;
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
   });
 
@@ -36,7 +36,7 @@ describe('clearUserData for Highlights data', () => {
     });
     await highlightService.deleteByAnnotationIds(
       ['1', '2', '3', '4'],
-      'requestId'
+      'requestId',
     );
     const res = await db('user_annotations')
       .select()
@@ -59,7 +59,7 @@ describe('clearUserData for Highlights data', () => {
       .pluck('user_id');
     await highlightService.deleteByAnnotationIds(
       ['1', '2', '3', '4'],
-      'requestId'
+      'requestId',
     );
     expect(res.length).toEqual(0);
   });

--- a/src/test/mutation/highlights-create.integration.ts
+++ b/src/test/mutation/highlights-create.integration.ts
@@ -26,10 +26,10 @@ describe('Highlights creation', () => {
   const testData = seedData(now);
   const truncateAndSeed = async () => {
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
   };
   beforeAll(async () => {
@@ -130,10 +130,10 @@ describe('Highlights creation', () => {
         .pluck('time_updated');
 
       expect(mysqlTimeString(listRecord[0])).toEqual(
-        mysqlTimeString(updateDate, config.database.tz)
+        mysqlTimeString(updateDate, config.database.tz),
       );
       expect(usersMetaRecord[0]).toEqual(
-        mysqlTimeString(updateDate, config.database.tz)
+        mysqlTimeString(updateDate, config.database.tz),
       );
 
       clock.restore();
@@ -378,7 +378,7 @@ describe('Highlights creation', () => {
         const expectedQuotes = variables.input.map((_) => _.quote);
         const actualQuotes = result.map((_) => _.quote);
         expect(actualQuotes).toEqual(expect.arrayContaining(expectedQuotes));
-      }
+      },
     );
   });
 });

--- a/src/test/mutation/highlights-delete.integration.ts
+++ b/src/test/mutation/highlights-delete.integration.ts
@@ -23,10 +23,10 @@ describe('Highlights deletion', () => {
   const testData = seedData(now);
   const truncateAndSeed = async () => {
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
   };
 
@@ -69,10 +69,10 @@ describe('Highlights deletion', () => {
     expect(res.body.data?.deleteSavedItemHighlight).toBe(variables.id);
     expect(annotationRecord[0].status).toBe(0);
     expect(usersMetaRecord[0]).toEqual(
-      mysqlTimeString(updateDate, config.database.tz)
+      mysqlTimeString(updateDate, config.database.tz),
     );
     expect(mysqlTimeString(listRecord[0])).toEqual(
-      mysqlTimeString(updateDate, config.database.tz)
+      mysqlTimeString(updateDate, config.database.tz),
     );
 
     clock.restore();
@@ -88,7 +88,7 @@ describe('Highlights deletion', () => {
 
     if (res.body.errors) {
       expect(res.body.errors[0].message).toBe(
-        'Error - Not Found: No annotation found for the given ID'
+        'Error - Not Found: No annotation found for the given ID',
       );
     }
   });

--- a/src/test/mutation/highlights-update.integration.ts
+++ b/src/test/mutation/highlights-update.integration.ts
@@ -22,10 +22,10 @@ describe('Highlights update', () => {
   const testData = seedData(now);
   const truncateAndSeed = async () => {
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
   };
   beforeAll(async () => {
@@ -70,14 +70,14 @@ describe('Highlights update', () => {
     expect(res.body.data?.updateSavedItemHighlight.patch).toEqual(input.patch);
     expect(res.body.data?.updateSavedItemHighlight.quote).toEqual(input.quote);
     expect(res.body.data?.updateSavedItemHighlight.version).toEqual(
-      input.version
+      input.version,
     );
     expect(res.body.data?.updateSavedItemHighlight.id).toEqual(id);
     expect(usersMetaRecord[0]).toEqual(
-      mysqlTimeString(updateDate, config.database.tz)
+      mysqlTimeString(updateDate, config.database.tz),
     );
     expect(mysqlTimeString(listRecord[0])).toEqual(
-      mysqlTimeString(updateDate, config.database.tz)
+      mysqlTimeString(updateDate, config.database.tz),
     );
 
     clock.restore();
@@ -97,7 +97,7 @@ describe('Highlights update', () => {
       .set(headers)
       .send({ query: print(UPDATE_HIGHLIGHT), variables });
     expect(res.body.errors?.[0]?.message).toContain(
-      'Error - Not Found: No annotation found for the given ID'
+      'Error - Not Found: No annotation found for the given ID',
     );
 
     expect(res.body.errors?.[0]?.extensions?.code).toEqual('NOT_FOUND');
@@ -133,7 +133,7 @@ describe('Highlights update', () => {
 
     expect(dbRow.length).toEqual(1);
     expect(res.body.errors?.[0].message).toContain(
-      'Error - Not Found: No annotation found for the given ID'
+      'Error - Not Found: No annotation found for the given ID',
     );
   });
 });

--- a/src/test/mutation/notes-create.integration.ts
+++ b/src/test/mutation/notes-create.integration.ts
@@ -19,10 +19,10 @@ describe('Notes creation', () => {
   const testData = seedData(now);
   const truncateAndSeed = async () => {
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
   };
   beforeAll(async () => {
@@ -84,7 +84,7 @@ describe('Notes creation', () => {
       expect(res.body.data?.createSavedItemHighlightNote).toBeNull();
       expect(res.body.errors?.length).toEqual(1);
       expect(res.body.errors?.[0].message).toContain(
-        'Premium account required'
+        'Premium account required',
       );
     });
   });

--- a/src/test/mutation/notes-delete.integration.ts
+++ b/src/test/mutation/notes-delete.integration.ts
@@ -30,10 +30,10 @@ describe('Notes delete', () => {
   beforeAll(async () => {
     ({ app, server, url: graphQLUrl } = await startServer(0));
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
     await dynamodb.send(noteSeedCommand(now));
   });
@@ -90,7 +90,7 @@ describe('Notes delete', () => {
       expect(res.body.data).toBeNull();
       expect(res.body.errors?.length).toEqual(1);
       expect(res.body.errors?.[0].message).toContain(
-        'Premium account required'
+        'Premium account required',
       );
     });
   });

--- a/src/test/mutation/notes-update.integration.ts
+++ b/src/test/mutation/notes-update.integration.ts
@@ -31,10 +31,10 @@ describe('Notes update', () => {
   beforeAll(async () => {
     ({ app, server, url: graphQLUrl } = await startServer(0));
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
     await dynamodb.send(noteSeedCommand(now));
   });
@@ -75,7 +75,7 @@ describe('Notes update', () => {
       expect(result).toEqual(expect.objectContaining(expectedHighlight));
       const dbRecord = await new NotesDataService(dynamoClient(), '1').get('1');
       expect(dbRecord?.text).toEqual(
-        'sweeter than a bucket full of strawberries'
+        'sweeter than a bucket full of strawberries',
       );
     });
     it('returns NOT_FOUND if the highlight does not exist', async () => {
@@ -108,7 +108,7 @@ describe('Notes update', () => {
       expect(res.body.data?.updateSavedItemHighlightNote).toBeNull();
       expect(res.body.errors?.length).toEqual(1);
       expect(res.body.errors?.[0].message).toContain(
-        'Premium account required'
+        'Premium account required',
       );
     });
   });

--- a/src/test/query/highlights.integration.ts
+++ b/src/test/query/highlights.integration.ts
@@ -18,10 +18,10 @@ describe('Highlights on a SavedItem', () => {
 
   beforeAll(async () => {
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
     ({ app, server, url: graphQLUrl } = await startServer(0));
   });
@@ -63,7 +63,7 @@ describe('Highlights on a SavedItem', () => {
     expect(res).toBeTruthy();
     expect(annotations).toHaveLength(2);
     expect(annotations.map((_) => _.quote)).toEqual(
-      expect.arrayContaining(expectedQuotes)
+      expect.arrayContaining(expectedQuotes),
     );
   });
   it('should return an empty Highlights array if there are no highlights on a SavedItem', async () => {

--- a/src/test/query/notes-fixtures.ts
+++ b/src/test/query/notes-fixtures.ts
@@ -38,7 +38,7 @@ export const noteSeedCommand = (now: Date): PutCommand => {
 
 export function* batchWriteMockNotes(
   count: number,
-  userId: string
+  userId: string,
 ): Generator<BatchWriteCommandInput> {
   const chance = new Chance();
   const batchSize = 25;

--- a/src/test/query/notes.integration.ts
+++ b/src/test/query/notes.integration.ts
@@ -27,10 +27,10 @@ describe('Notes on a Highlight', () => {
 
   beforeAll(async () => {
     await Promise.all(
-      Object.keys(testData).map((table) => db(table).truncate())
+      Object.keys(testData).map((table) => db(table).truncate()),
     );
     await Promise.all(
-      Object.entries(testData).map(([table, data]) => db(table).insert(data))
+      Object.entries(testData).map(([table, data]) => db(table).insert(data)),
     );
     await dynamodb.send(noteSeedCommand(now));
     ({ app, server, url: graphQLUrl } = await startServer(0));

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -3,5 +3,5 @@ import fs from 'fs';
 import { gql } from 'graphql-tag';
 
 export default gql(
-  fs.readFileSync(path.join(__dirname, '..', 'schema.graphql')).toString()
+  fs.readFileSync(path.join(__dirname, '..', 'schema.graphql')).toString(),
 );

--- a/src/utils/dataAggregation.ts
+++ b/src/utils/dataAggregation.ts
@@ -17,16 +17,19 @@ interface NumericObject {
  */
 export function groupByCount<T extends IndexableObject, Key extends keyof T>(
   data: T[],
-  key: Key
+  key: Key,
 ): Record<T[Key], number> {
-  return data.reduce((counts, element) => {
-    if (key in element) {
-      counts[element[key]] != null
-        ? (counts[element[key]] += 1)
-        : (counts[element[key]] = 1);
-    }
-    return counts;
-  }, {} as Record<T[Key], number>);
+  return data.reduce(
+    (counts, element) => {
+      if (key in element) {
+        counts[element[key]] != null
+          ? (counts[element[key]] += 1)
+          : (counts[element[key]] = 1);
+      }
+      return counts;
+    },
+    {} as Record<T[Key], number>,
+  );
 }
 
 /**
@@ -39,7 +42,7 @@ export function groupByCount<T extends IndexableObject, Key extends keyof T>(
  */
 export function sumByKey<T extends NumericObject, Key extends keyof T>(
   base: T | undefined,
-  addition: T | undefined
+  addition: T | undefined,
 ): Record<T[Key], number> {
   if (addition == null) {
     return { ...base };
@@ -49,6 +52,6 @@ export function sumByKey<T extends NumericObject, Key extends keyof T>(
       total[key] != null ? (total[key] += value) : (total[key] = value);
       return total;
     },
-    { ...base } as Record<T[Key], number>
+    { ...base } as Record<T[Key], number>,
   );
 }


### PR DESCRIPTION
## Goal

- Updated the `eslint-config` package and any code that needed extra commas to satisfy the new linting rules.
- Removed the `@apollo/server-plugin-landing-page-graphql-playground` package as it was EOL in Dec 2022. Using a newer plugin that is bundled with `@apollo/server` instead.

## References

https://getpocket.atlassian.net/browse/INFRA-1372