### PR TITLE
Chore: Add Slack notification to CircleCI workfows (prod)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ orbs:
   backstage-entity-validator: roadiehq/backstage-entity-validator@0.4.2
   path-filtering: circleci/path-filtering@1.0.0
   continuation: circleci/continuation@1.0.0
+  slack: circleci/slack@4.12.5
 
 # Workflow shortcuts
 # You can remove unnecessary shortcuts as applicable
@@ -54,6 +55,13 @@ only_dev: &only_dev
     branches:
       only:
         - dev
+# Use for notifying failure of step
+slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - slack/notify:
+        branch_pattern: main
+        event: fail
+        template: basic_fail_1
 
 jobs:
   apollo:
@@ -248,10 +256,15 @@ workflows:
           context: pocket
           name: test_integrations
 
-      - apollo
+      - apollo:
+          context: pocket
+          requires:
+            - build
+          <<: *slack-fail-post-step
 
       - build:
           context: pocket
+          <<: *slack-fail-post-step
 
       # Try building the ECS docker image on each branch
       - pocket/docker_build:
@@ -302,6 +315,7 @@ workflows:
       - pocket/docker_build:
           <<: *only_main
           context: pocket
+          <<: *slack-fail-post-step
           name: build_docker_prod
           aws-access-key-id: Prod_AWS_ACCESS_KEY
           aws-secret-access-key: Prod_AWS_SECRET_ACCESS_KEY
@@ -318,6 +332,7 @@ workflows:
       - pocket/execute_codepipeline:
           <<: *only_main
           context: pocket
+          <<: *slack-fail-post-step
           name: deploy_prod
           environment: Prod
           aws-access-key-id: Prod_AWS_ACCESS_KEY
@@ -332,6 +347,7 @@ workflows:
       # Prod
       - pocket/setup_deploy_params:
           <<: *only_main
+          <<: *slack-fail-post-step
           name: setup-deploy-params-prod
           aws_access_key_id: Prod_AWS_ACCESS_KEY
           aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -5,6 +5,7 @@ setup: false
 orbs:
   pocket: pocket/circleci-orbs@2.1.1
   aws-cli: circleci/aws-cli@3.1.5
+  slack: circleci/slack@4.12.5
 # the default pipeline parameters, which will be updated according to
 # the results of the path-filtering orb
 parameters:
@@ -35,6 +36,14 @@ only_dev: &only_dev
     branches:
       only:
         - dev
+        -
+# Use for notifying failure of step
+slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - slack/notify:
+        branch_pattern: main
+        event: fail
+        template: basic_fail_1
 
 jobs:
   lambda:
@@ -180,6 +189,7 @@ workflows:
       # Build & Deploy Production Lambdas
       - lambda:
           <<: *only_main
+          <<: *slack-fail-post-step
           context: pocket
           name: deploy_lambda_events_prod
           env_lower_name: prod

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -36,7 +36,7 @@ only_dev: &only_dev
     branches:
       only:
         - dev
-        -
+
 # Use for notifying failure of step
 slack-fail-post-step: &slack-fail-post-step
   post-steps:


### PR DESCRIPTION
## Goal
Add Slack notification to CircleCI all workflow when any pipeline in Prod fails. For now, the notifications go to the Pocket slack channel `#log-backend-deploys`. If we want to move these notifications to the Mozilla slack to a similar channel, someone with permissions need to configure the Slack/Circleci-Deployment Bot.



## References

JIRA ticket:
* [https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-432](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-432)
