### PR TITLE
chore(deps): [INFRA-1372] Update Sentry to v.7

### DIFF
--- a/lambda/events/package-lock.json
+++ b/lambda/events/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-lambda": "3.391.0",
-        "@sentry/serverless": "^6.18.2",
+        "@sentry/serverless": "7.64.0",
         "@types/node": "18.17.1",
         "aws-lambda": "^1.0.7",
         "node-fetch": "^2.6.7",
@@ -1493,152 +1493,87 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.64.0.tgz",
+      "integrity": "sha512-1XE8W6ki7hHyBvX9hfirnGkKDBKNq3bDJyXS86E0bYVDl94nvbRM9BD9DHsCFetqYkVm1yDGEK+6aUVs4CztoQ==",
+      "dependencies": {
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sentry/core": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.2.tgz",
-      "integrity": "sha512-r5ad/gq5S/JHc9sd5CUhZQT9ojQ+f+thk/AoGeGawX/8HURZYAgIqD565d6FK0VsZEDkdRMl58z1Qon20h3y1g==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.64.0.tgz",
+      "integrity": "sha512-IzmEyl5sNG7NyEFiyFHEHC+sizsZp9MEw1+RJRLX6U5RITvcsEgcajSkHQFafaBPzRrcxZMdm47Cwhl212LXcw==",
       "dependencies": {
-        "@sentry/hub": "6.18.2",
-        "@sentry/minimal": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
-    },
-    "node_modules/@sentry/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/hub": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.2.tgz",
-      "integrity": "sha512-d0AugekMkbnN12b4EXMjseJxtLPc9S20DGobCPUb4oAQT6S2oDQEj1jwP6PQ5vtgyy+GMYWxBMgqAQ4pjVYISQ==",
-      "dependencies": {
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.2.tgz",
-      "integrity": "sha512-n7KYuo34W2LxE+3dnZ47of7XHuORINCnXq66XH72eoj67tf0XeWbIhEJrYGmoLRyRfoCYYrBLWiDl/uTjLzrzQ==",
-      "dependencies": {
-        "@sentry/hub": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.2.tgz",
-      "integrity": "sha512-1S+44c09n3KVpCYjwOfnA9jKvnpPegpQWM81Nu5J6ToGx+ZiddMq6B9GRXUnFfZ7Z6fJHZzFtySasQC7KqkQoA==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.64.0.tgz",
+      "integrity": "sha512-wRi0uTnp1WSa83X2yLD49tV9QPzGh5e42IKdIDBiQ7lV9JhLILlyb34BZY1pq6p4dp35yDasDrP3C7ubn7wo6A==",
       "dependencies": {
-        "@sentry/core": "6.18.2",
-        "@sentry/hub": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
+        "@sentry-internal/tracing": "7.64.0",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
-    "node_modules/@sentry/node/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@sentry/serverless": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-6.18.2.tgz",
-      "integrity": "sha512-5aS+QnADeWxs1n9i2xVPcFRJuqH+3Aua8Z55ySNoSZVN4pBNKxasjHsectswSejmD7cmSGWma7Clb+QaYttscQ==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-7.64.0.tgz",
+      "integrity": "sha512-8lXcHW52xAO1YRgM5T9+xrl5wd6u0TNGRk338I+sGkyZwVQ/1sqxtvftyl13NrMa86wmAU5a91Yzge2YUAxGYQ==",
       "dependencies": {
-        "@sentry/minimal": "6.18.2",
-        "@sentry/node": "6.18.2",
-        "@sentry/tracing": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
+        "@sentry/core": "7.64.0",
+        "@sentry/node": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "@types/aws-lambda": "^8.10.62",
-        "@types/express": "^4.17.2",
-        "tslib": "^1.9.3"
+        "@types/express": "^4.17.14",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/serverless/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.18.2.tgz",
-      "integrity": "sha512-hg6NLqrqJ5sUPTyWEQ2RqdnhQVnyLtx8II0IyWxQLDWD8UCe3Mu6G7mroDtakPWcP+lWz6OnKfMEfuhMcxR8fw==",
-      "dependencies": {
-        "@sentry/hub": "6.18.2",
-        "@sentry/minimal": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/tracing/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@sentry/types": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
-      "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+      "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.2.tgz",
-      "integrity": "sha512-EC619jesknyu4xpwud5WC/5odYLz6JUy7OSFy5405PpdGeh/m8XUvuJAx4zDx0Iz/Mlk0S1Md+ZcQwqkv39dkw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+      "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
       "dependencies": {
-        "@sentry/types": "6.18.2",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
-    },
-    "node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2294,24 +2229,25 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+      "version": "4.17.35",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
+      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -2322,6 +2258,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -2387,12 +2328,22 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
-    "node_modules/@types/serve-static": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+    "node_modules/@types/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
       "dependencies": {
         "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
+      "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
         "@types/node": "*"
       }
     },
@@ -6741,141 +6692,68 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@sentry-internal/tracing": {
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.64.0.tgz",
+      "integrity": "sha512-1XE8W6ki7hHyBvX9hfirnGkKDBKNq3bDJyXS86E0bYVDl94nvbRM9BD9DHsCFetqYkVm1yDGEK+6aUVs4CztoQ==",
+      "requires": {
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      }
+    },
     "@sentry/core": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.2.tgz",
-      "integrity": "sha512-r5ad/gq5S/JHc9sd5CUhZQT9ojQ+f+thk/AoGeGawX/8HURZYAgIqD565d6FK0VsZEDkdRMl58z1Qon20h3y1g==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.64.0.tgz",
+      "integrity": "sha512-IzmEyl5sNG7NyEFiyFHEHC+sizsZp9MEw1+RJRLX6U5RITvcsEgcajSkHQFafaBPzRrcxZMdm47Cwhl212LXcw==",
       "requires": {
-        "@sentry/hub": "6.18.2",
-        "@sentry/minimal": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@sentry/hub": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.2.tgz",
-      "integrity": "sha512-d0AugekMkbnN12b4EXMjseJxtLPc9S20DGobCPUb4oAQT6S2oDQEj1jwP6PQ5vtgyy+GMYWxBMgqAQ4pjVYISQ==",
-      "requires": {
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.2.tgz",
-      "integrity": "sha512-n7KYuo34W2LxE+3dnZ47of7XHuORINCnXq66XH72eoj67tf0XeWbIhEJrYGmoLRyRfoCYYrBLWiDl/uTjLzrzQ==",
-      "requires": {
-        "@sentry/hub": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.2.tgz",
-      "integrity": "sha512-1S+44c09n3KVpCYjwOfnA9jKvnpPegpQWM81Nu5J6ToGx+ZiddMq6B9GRXUnFfZ7Z6fJHZzFtySasQC7KqkQoA==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.64.0.tgz",
+      "integrity": "sha512-wRi0uTnp1WSa83X2yLD49tV9QPzGh5e42IKdIDBiQ7lV9JhLILlyb34BZY1pq6p4dp35yDasDrP3C7ubn7wo6A==",
       "requires": {
-        "@sentry/core": "6.18.2",
-        "@sentry/hub": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
+        "@sentry-internal/tracing": "7.64.0",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/serverless": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-6.18.2.tgz",
-      "integrity": "sha512-5aS+QnADeWxs1n9i2xVPcFRJuqH+3Aua8Z55ySNoSZVN4pBNKxasjHsectswSejmD7cmSGWma7Clb+QaYttscQ==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-7.64.0.tgz",
+      "integrity": "sha512-8lXcHW52xAO1YRgM5T9+xrl5wd6u0TNGRk338I+sGkyZwVQ/1sqxtvftyl13NrMa86wmAU5a91Yzge2YUAxGYQ==",
       "requires": {
-        "@sentry/minimal": "6.18.2",
-        "@sentry/node": "6.18.2",
-        "@sentry/tracing": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
+        "@sentry/core": "7.64.0",
+        "@sentry/node": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "@types/aws-lambda": "^8.10.62",
-        "@types/express": "^4.17.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@sentry/tracing": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.18.2.tgz",
-      "integrity": "sha512-hg6NLqrqJ5sUPTyWEQ2RqdnhQVnyLtx8II0IyWxQLDWD8UCe3Mu6G7mroDtakPWcP+lWz6OnKfMEfuhMcxR8fw==",
-      "requires": {
-        "@sentry/hub": "6.18.2",
-        "@sentry/minimal": "6.18.2",
-        "@sentry/types": "6.18.2",
-        "@sentry/utils": "6.18.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@types/express": "^4.17.14",
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
-      "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw=="
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+      "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA=="
     },
     "@sentry/utils": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.2.tgz",
-      "integrity": "sha512-EC619jesknyu4xpwud5WC/5odYLz6JUy7OSFy5405PpdGeh/m8XUvuJAx4zDx0Iz/Mlk0S1Md+ZcQwqkv39dkw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+      "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
       "requires": {
-        "@sentry/types": "6.18.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/types": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sinclair/typebox": {
@@ -7420,24 +7298,25 @@
       }
     },
     "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+      "version": "4.17.35",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
+      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "@types/graceful-fs": {
@@ -7448,6 +7327,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -7513,12 +7397,22 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
-    "@types/serve-static": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+    "@types/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
       "requires": {
         "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
+      "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
+      "requires": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
         "@types/node": "*"
       }
     },

--- a/lambda/events/package.json
+++ b/lambda/events/package.json
@@ -12,19 +12,19 @@
   "license": "ISC",
   "dependencies": {
     "@aws-sdk/client-lambda": "3.391.0",
-    "@sentry/serverless": "^6.18.2",
+    "@sentry/serverless": "7.64.0",
     "@types/node": "18.17.1",
     "aws-lambda": "^1.0.7",
-    "typescript": "5.1.6",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.7",
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.119",
     "@types/jest": "29.5.3",
+    "@types/node-fetch": "2.6.4",
     "@types/sinon": "10.0.15",
     "jest": "29.6.2",
     "nock": "13.3.2",
-    "@types/node-fetch": "2.6.4",
     "sinon": "15.2.0",
     "ts-jest": "29.1.1"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
         "@aws-sdk/lib-dynamodb": "3.391.0",
         "@pocket-tools/apollo-utils": "^3.4.0",
         "@pocket-tools/ts-logger": "^1.2.4",
-        "@sentry/node": "6.19.7",
-        "@sentry/tracing": "6.19.7",
+        "@sentry/node": "7.64.0",
+        "@sentry/tracing": "7.64.0",
         "apollo-server-cache-redis": "3.3.1",
         "chai-shallow-deep-equal": "^1.4.6",
         "cors": "2.8.5",
@@ -35,6 +35,7 @@
       "devDependencies": {
         "@pocket-tools/eslint-config": "2.1.7",
         "@pocket-tools/tsconfig": "2.0.1",
+        "@sentry/types": "7.64.0",
         "@types/chai": "4.3.5",
         "@types/chance": "1.1.3",
         "@types/jest": "29.5.3",
@@ -2372,57 +2373,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@pocket-tools/apollo-utils/node_modules/@sentry/core": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.1.tgz",
-      "integrity": "sha512-yr/0VFYWOJyXj+F2nifkRYxXskotsNnDggUnFOZZN2ZgTG94IzRFsOZQ6RslHJ8nrYPTBNO74reU0C0GB++xRw==",
-      "dependencies": {
-        "@sentry/types": "7.60.1",
-        "@sentry/utils": "7.60.1",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@pocket-tools/apollo-utils/node_modules/@sentry/node": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.60.1.tgz",
-      "integrity": "sha512-lBt3RqncY4XbzM+PlTbH/tUWeOsm24anwEzvA2DSDP1NL3WZ5MdvT77q7NqpvpVNd2LeGAQ6x7AXDzE53YBfnQ==",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.60.1",
-        "@sentry/core": "7.60.1",
-        "@sentry/types": "7.60.1",
-        "@sentry/utils": "7.60.1",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@pocket-tools/apollo-utils/node_modules/@sentry/types": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.1.tgz",
-      "integrity": "sha512-8lKKSCOhZ953cWxwnfZwoR3ZFFlZG4P3PQFTaFt/u4LxLh/0zYbdtgvtUqXRURjMCi5P6ddeE9Uw9FGnTJCsTw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@pocket-tools/apollo-utils/node_modules/@sentry/utils": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.1.tgz",
-      "integrity": "sha512-ik+5sKGBx4DWuvf6UUKPSafaDiASxP+Xvjg3C9ppop2I/JWxP1FfZ5g22n5ZmPmNahD6clTSoTWly8qyDUlUOw==",
-      "dependencies": {
-        "@sentry/types": "7.60.1",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@pocket-tools/apollo-utils/node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -2998,46 +2948,13 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.60.1.tgz",
-      "integrity": "sha512-2vM+3/ddzmoBfi92OOD9FFTHXf0HdQhKtNM26+/RsmkKnTid+/inbvA7nKi+Qa7ExcnlC6eclEHQEg+0X3yDkQ==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.64.0.tgz",
+      "integrity": "sha512-1XE8W6ki7hHyBvX9hfirnGkKDBKNq3bDJyXS86E0bYVDl94nvbRM9BD9DHsCFetqYkVm1yDGEK+6aUVs4CztoQ==",
       "dependencies": {
-        "@sentry/core": "7.60.1",
-        "@sentry/types": "7.60.1",
-        "@sentry/utils": "7.60.1",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.1.tgz",
-      "integrity": "sha512-yr/0VFYWOJyXj+F2nifkRYxXskotsNnDggUnFOZZN2ZgTG94IzRFsOZQ6RslHJ8nrYPTBNO74reU0C0GB++xRw==",
-      "dependencies": {
-        "@sentry/types": "7.60.1",
-        "@sentry/utils": "7.60.1",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.1.tgz",
-      "integrity": "sha512-8lKKSCOhZ953cWxwnfZwoR3ZFFlZG4P3PQFTaFt/u4LxLh/0zYbdtgvtUqXRURjMCi5P6ddeE9Uw9FGnTJCsTw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.1.tgz",
-      "integrity": "sha512-ik+5sKGBx4DWuvf6UUKPSafaDiASxP+Xvjg3C9ppop2I/JWxP1FfZ5g22n5ZmPmNahD6clTSoTWly8qyDUlUOw==",
-      "dependencies": {
-        "@sentry/types": "7.60.1",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -3045,128 +2962,66 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.64.0.tgz",
+      "integrity": "sha512-IzmEyl5sNG7NyEFiyFHEHC+sizsZp9MEw1+RJRLX6U5RITvcsEgcajSkHQFafaBPzRrcxZMdm47Cwhl212LXcw==",
       "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
-    },
-    "node_modules/@sentry/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
-      "dependencies": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.64.0.tgz",
+      "integrity": "sha512-wRi0uTnp1WSa83X2yLD49tV9QPzGh5e42IKdIDBiQ7lV9JhLILlyb34BZY1pq6p4dp35yDasDrP3C7ubn7wo6A==",
       "dependencies": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry-internal/tracing": "7.64.0",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
-    },
-    "node_modules/@sentry/node/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.7.tgz",
-      "integrity": "sha512-ol4TupNnv9Zd+bZei7B6Ygnr9N3Gp1PUrNI761QSlHtPC25xXC5ssSD3GMhBgyQrcvpuRcCFHVNNM97tN5cZiA==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.64.0.tgz",
+      "integrity": "sha512-Php0XnnJolfxkFdgLlgwgRz3bgHmu/7gDRQaGQHJeDgCCjrmNHI+sHi8zmkWCWSO0Z1mi111n2ZUr9B9YLPBTg==",
       "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry-internal/tracing": "7.64.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
-    "node_modules/@sentry/tracing/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+      "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+      "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
       "dependencies": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
-    },
-    "node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -3801,12 +3656,12 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
@@ -16438,45 +16293,6 @@
             "jest-mock": "^29.6.1"
           }
         },
-        "@sentry/core": {
-          "version": "7.60.1",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.1.tgz",
-          "integrity": "sha512-yr/0VFYWOJyXj+F2nifkRYxXskotsNnDggUnFOZZN2ZgTG94IzRFsOZQ6RslHJ8nrYPTBNO74reU0C0GB++xRw==",
-          "requires": {
-            "@sentry/types": "7.60.1",
-            "@sentry/utils": "7.60.1",
-            "tslib": "^2.4.1 || ^1.9.3"
-          }
-        },
-        "@sentry/node": {
-          "version": "7.60.1",
-          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.60.1.tgz",
-          "integrity": "sha512-lBt3RqncY4XbzM+PlTbH/tUWeOsm24anwEzvA2DSDP1NL3WZ5MdvT77q7NqpvpVNd2LeGAQ6x7AXDzE53YBfnQ==",
-          "requires": {
-            "@sentry-internal/tracing": "7.60.1",
-            "@sentry/core": "7.60.1",
-            "@sentry/types": "7.60.1",
-            "@sentry/utils": "7.60.1",
-            "cookie": "^0.4.1",
-            "https-proxy-agent": "^5.0.0",
-            "lru_map": "^0.3.3",
-            "tslib": "^2.4.1 || ^1.9.3"
-          }
-        },
-        "@sentry/types": {
-          "version": "7.60.1",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.1.tgz",
-          "integrity": "sha512-8lKKSCOhZ953cWxwnfZwoR3ZFFlZG4P3PQFTaFt/u4LxLh/0zYbdtgvtUqXRURjMCi5P6ddeE9Uw9FGnTJCsTw=="
-        },
-        "@sentry/utils": {
-          "version": "7.60.1",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.1.tgz",
-          "integrity": "sha512-ik+5sKGBx4DWuvf6UUKPSafaDiASxP+Xvjg3C9ppop2I/JWxP1FfZ5g22n5ZmPmNahD6clTSoTWly8qyDUlUOw==",
-          "requires": {
-            "@sentry/types": "7.60.1",
-            "tslib": "^2.4.1 || ^1.9.3"
-          }
-        },
         "denque": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -16875,155 +16691,61 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.60.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.60.1.tgz",
-      "integrity": "sha512-2vM+3/ddzmoBfi92OOD9FFTHXf0HdQhKtNM26+/RsmkKnTid+/inbvA7nKi+Qa7ExcnlC6eclEHQEg+0X3yDkQ==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.64.0.tgz",
+      "integrity": "sha512-1XE8W6ki7hHyBvX9hfirnGkKDBKNq3bDJyXS86E0bYVDl94nvbRM9BD9DHsCFetqYkVm1yDGEK+6aUVs4CztoQ==",
       "requires": {
-        "@sentry/core": "7.60.1",
-        "@sentry/types": "7.60.1",
-        "@sentry/utils": "7.60.1",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "dependencies": {
-        "@sentry/core": {
-          "version": "7.60.1",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.1.tgz",
-          "integrity": "sha512-yr/0VFYWOJyXj+F2nifkRYxXskotsNnDggUnFOZZN2ZgTG94IzRFsOZQ6RslHJ8nrYPTBNO74reU0C0GB++xRw==",
-          "requires": {
-            "@sentry/types": "7.60.1",
-            "@sentry/utils": "7.60.1",
-            "tslib": "^2.4.1 || ^1.9.3"
-          }
-        },
-        "@sentry/types": {
-          "version": "7.60.1",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.1.tgz",
-          "integrity": "sha512-8lKKSCOhZ953cWxwnfZwoR3ZFFlZG4P3PQFTaFt/u4LxLh/0zYbdtgvtUqXRURjMCi5P6ddeE9Uw9FGnTJCsTw=="
-        },
-        "@sentry/utils": {
-          "version": "7.60.1",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.1.tgz",
-          "integrity": "sha512-ik+5sKGBx4DWuvf6UUKPSafaDiASxP+Xvjg3C9ppop2I/JWxP1FfZ5g22n5ZmPmNahD6clTSoTWly8qyDUlUOw==",
-          "requires": {
-            "@sentry/types": "7.60.1",
-            "tslib": "^2.4.1 || ^1.9.3"
-          }
-        }
       }
     },
     "@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.64.0.tgz",
+      "integrity": "sha512-IzmEyl5sNG7NyEFiyFHEHC+sizsZp9MEw1+RJRLX6U5RITvcsEgcajSkHQFafaBPzRrcxZMdm47Cwhl212LXcw==",
       "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
-      "requires": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.64.0.tgz",
+      "integrity": "sha512-wRi0uTnp1WSa83X2yLD49tV9QPzGh5e42IKdIDBiQ7lV9JhLILlyb34BZY1pq6p4dp35yDasDrP3C7ubn7wo6A==",
       "requires": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry-internal/tracing": "7.64.0",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/tracing": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.7.tgz",
-      "integrity": "sha512-ol4TupNnv9Zd+bZei7B6Ygnr9N3Gp1PUrNI761QSlHtPC25xXC5ssSD3GMhBgyQrcvpuRcCFHVNNM97tN5cZiA==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.64.0.tgz",
+      "integrity": "sha512-Php0XnnJolfxkFdgLlgwgRz3bgHmu/7gDRQaGQHJeDgCCjrmNHI+sHi8zmkWCWSO0Z1mi111n2ZUr9B9YLPBTg==",
       "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry-internal/tracing": "7.64.0"
       }
     },
     "@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg=="
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+      "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA=="
     },
     "@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+      "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
       "requires": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/types": "7.64.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sinclair/typebox": {
@@ -17559,12 +17281,12 @@
       }
     },
     "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "@aws-sdk/lib-dynamodb": "3.391.0",
     "@pocket-tools/apollo-utils": "^3.4.0",
     "@pocket-tools/ts-logger": "^1.2.4",
-    "@sentry/node": "6.19.7",
-    "@sentry/tracing": "6.19.7",
+    "@sentry/node": "7.64.0",
+    "@sentry/tracing": "7.64.0",
     "apollo-server-cache-redis": "3.3.1",
     "chai-shallow-deep-equal": "^1.4.6",
     "cors": "2.8.5",
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@pocket-tools/eslint-config": "2.1.7",
     "@pocket-tools/tsconfig": "2.0.1",
+    "@sentry/types": "7.64.0",
     "@types/chai": "4.3.5",
     "@types/chance": "1.1.3",
     "@types/jest": "29.5.3",

--- a/src/server/aws/batchDeleteHandler.spec.ts
+++ b/src/server/aws/batchDeleteHandler.spec.ts
@@ -4,6 +4,7 @@ import { BatchDeleteHandler, BatchDeleteMessage } from './batchDeleteHandler';
 import { DeleteMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { HighlightsDataService } from '../../dataservices/highlights';
 import * as Sentry from '@sentry/node';
+import { SeverityLevel } from '@sentry/types';
 import config from '../../config';
 import { serverLogger } from '../';
 
@@ -54,7 +55,7 @@ describe('batchDeleteHandler', () => {
     await batchDeleteHandler.pollQueue();
     expect(
       sentryStub.calledOnceWithExactly(error, {
-        level: Sentry.Severity.Critical,
+        level: 'fatal' as SeverityLevel,
       }),
     ).toBe(true);
     expect(serverLoggerStub.callCount).toEqual(1);

--- a/src/server/aws/batchDeleteHandler.ts
+++ b/src/server/aws/batchDeleteHandler.ts
@@ -14,6 +14,7 @@ import { HighlightsDataService } from '../../dataservices/highlights';
 import { setTimeout } from 'timers/promises';
 import { failCallback } from '../routes/helper';
 import { serverLogger } from '../';
+import { SeverityLevel } from '@sentry/types';
 
 export type BatchDeleteMessage = {
   traceId: string;
@@ -156,7 +157,7 @@ export class BatchDeleteHandler {
       const receiveError = 'Error receiving messages from queue';
       serverLogger.error(receiveError, error);
       Sentry.addBreadcrumb({ message: receiveError });
-      Sentry.captureException(error, { level: Sentry.Severity.Critical });
+      Sentry.captureException(error, { level: 'fatal' as SeverityLevel });
     }
     // Process any messages received and schedule next poll
     if (body != null) {


### PR DESCRIPTION
## Goal

Update Sentry from v.6 to v.7 

- [x] Update existing Sentry packages to v.7
- [x] Add `@sentry/types`, as, according to [this migration guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#severity-severitylevel-and-severitylevels), it's now needed to use the new type rather than an enum in the code.
- [x] Update code in a couple of places where deprecated usage was found

## References

https://getpocket.atlassian.net/browse/INFRA-1372